### PR TITLE
Add ID and URI to module outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ module "pubsub" {
 
 | Name | Description |
 |------|-------------|
+| id | The ID of the Pub/Sub topic |
 | subscription_names | The name list of Pub/Sub subscriptions |
 | subscription_paths | The path list of Pub/Sub subscriptions |
 | topic | The name of the Pub/Sub topic |
+| uri | The URI of the Pub/Sub topic |
 
 [^]: (autogen_docs_end)
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "topic" {
   description = "The name of the Pub/Sub topic"
 }
 
+output "topic_link" {
+  value       = "${google_pubsub_topic.topic.id}"
+  description = "The URI of the Pub/Sub topic"
+}
+
 output "subscription_names" {
   value = "${concat(
     google_pubsub_subscription.push_subscriptions.*.name,

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,11 @@ output "id" {
   description = "The ID of the Pub/Sub topic"
 }
 
+output "uri" {
+  value       = "pubsub.googleapis.com/${google_pubsub_topic.topic.id}"
+  description = "The URI of the Pub/Sub topic"
+}
+
 output "subscription_names" {
   value = "${concat(
     google_pubsub_subscription.push_subscriptions.*.name,

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "topic" {
   description = "The name of the Pub/Sub topic"
 }
 
-output "topic_link" {
+output "id" {
   value       = "${google_pubsub_topic.topic.id}"
   description = "The URI of the Pub/Sub topic"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output "topic" {
 
 output "id" {
   value       = "${google_pubsub_topic.topic.id}"
-  description = "The URI of the Pub/Sub topic"
+  description = "The ID of the Pub/Sub topic"
 }
 
 output "subscription_names" {


### PR DESCRIPTION
With this change topic name of output will be compliant with the following format.
```
  projects/[PROJECT_ID]/topics/[TOPIC_ID]
```
By this change, it will be more useful for combination with the following resources.

  - logging_project_sink
  - cloudiot_registry

@aaron-lane @morgante Could you take a look?