### PR TITLE
Refactor subscription outputs to use a map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .kitchen/
 .kitchen.local.yml
+.terraform/
+credentials.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
+project adheres to [Semantic Versioning](http://semver.org/).
+
+## [v0.3.0] - 2019-07-11
+
+### Added
+
+* Refactored subscription outputs [#5]
+
+### Changed
+
+* Updated example in README [#4]
+
+## [v0.2.0] - 2019-03-08
+
+### Added
+
+* Topic ID and URI outputs [#3]
+
+## [v0.1.0]
+
+### Added
+
+* Initial release of module.
+
+[v0.3.0]: https://github.com/terraform-google-modules/terraform-google-pubsub/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/terraform-google-modules/terraform-google-pubsub/compare/v0.1.0...v0.2.0
+[v0.1.0]: https://github.com/terraform-google-modules/terraform-google-pubsub/tree/v0.1.0
+
+[#5]: https://github.com/terraform-google-modules/terraform-google-pubsub/pull/5
+[#4]: https://github.com/terraform-google-modules/terraform-google-pubsub/pull/4
+[#3]: https://github.com/terraform-google-modules/terraform-google-pubsub/pull/3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a simple usage of the module. Please see also a simple setup provided in
 ```hcl
 module "pubsub" {
   source  = "terraform-google-modules/pubsub/google"
-  version = "~> 0.2.0"
+  version = "~> 0.3.0"
 
   topic              = "tf-topic"
   project_id         = "my-pubsub-project"
@@ -36,18 +36,19 @@ module "pubsub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| project_id | The project ID to manage the Pub/Sub resources | string | - | yes |
-| pull_subscriptions | The list of the pull subscriptions | list | `<list>` | no |
-| push_subscriptions | The list of the push subscriptions | list | `<list>` | no |
-| topic | The Pub/Sub topic name | string | - | yes |
+| project\_id | The project ID to manage the Pub/Sub resources | string | n/a | yes |
+| pull\_subscriptions | The list of the pull subscriptions | list | `<list>` | no |
+| push\_subscriptions | The list of the push subscriptions | list | `<list>` | no |
+| topic | The Pub/Sub topic name | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | id | The ID of the Pub/Sub topic |
-| subscription_names | The name list of Pub/Sub subscriptions |
-| subscription_paths | The path list of Pub/Sub subscriptions |
+| subscription\_names | The name list of Pub/Sub subscriptions |
+| subscription\_paths | The path list of Pub/Sub subscriptions |
+| subscriptions | A map containing the name and path key-value pairs of each created Pub/Sub subscription |
 | topic | The name of the Pub/Sub topic |
 | uri | The URI of the Pub/Sub topic |
 

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -14,26 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * Copyright 2018 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-output "project_id" {
-  value = "${var.project}"
-}
-
 output "topic" {
   value       = "${module.pubsub.topic}"
   description = "The name of the Pub/Sub topic"
@@ -47,6 +27,16 @@ output "id" {
 output "uri" {
   value       = "${module.pubsub.uri}"
   description = "The URI of the Pub/Sub topic"
+}
+
+output "subscription_names" {
+  value       = "${module.pubsub.subscription_names}"
+  description = "The name list of Pub/Sub subscriptions"
+}
+
+output "subscription_paths" {
+  value       = "${module.pubsub.subscription_paths}"
+  description = "The path list of Pub/Sub subscriptions"
 }
 
 output "subscriptions" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,3 +46,18 @@ output "subscription_paths" {
 
   description = "The path list of Pub/Sub subscriptions"
 }
+
+output "subscriptions" {
+  value = "${merge(
+    zipmap(
+      google_pubsub_subscription.push_subscriptions.*.name,
+      google_pubsub_subscription.push_subscriptions.*.path
+    ),
+    zipmap(
+      google_pubsub_subscription.pull_subscriptions.*.name,
+      google_pubsub_subscription.pull_subscriptions.*.path
+    )
+  )}"
+
+  description = "A map containing the name and path key-value pairs of each created Pub/Sub subscription"
+}

--- a/test/fixtures/main.tf
+++ b/test/fixtures/main.tf
@@ -25,7 +25,7 @@ module "pubsub" {
 
   push_subscriptions = [
     {
-      name                 = "push"
+      name                 = "pushy"
       push_endpoint        = "https://${var.project}.appspot.com/"
       x-goog-version       = "v1beta1"
       ack_deadline_seconds = 20
@@ -34,7 +34,7 @@ module "pubsub" {
 
   pull_subscriptions = [
     {
-      name = "pull"
+      name = "pulley"
     },
   ]
 }

--- a/test/integration/default/controls/pubsub.rb
+++ b/test/integration/default/controls/pubsub.rb
@@ -13,25 +13,25 @@
 # limitations under the License.
 
 project_id = attribute('project_id')
-topic      = attribute('topic_name')
+topic      = attribute('topic')
 
 describe command("gcloud --project='#{project_id}' pubsub topics describe #{topic}") do
   its(:exit_status) { should be_zero }
   it { expect(subject.stdout).to match(%r{name: projects/#{project_id}/topics/#{topic}}) }
 end
 
-describe command("gcloud --project='#{project_id}' pubsub subscriptions describe pull --format=json") do
+describe command("gcloud --project='#{project_id}' pubsub subscriptions describe pulley --format=json") do
   let(:stdout) { JSON.parse(subject.stdout, symbolize_names: true) }
   its(:exit_status) { should be_zero }
-  it { expect(stdout).to include(name: "projects/#{project_id}/subscriptions/pull") }
+  it { expect(stdout).to include(name: "projects/#{project_id}/subscriptions/pulley") }
   it { expect(stdout).to include(topic: "projects/#{project_id}/topics/#{topic}") }
   it { expect(stdout).to include(ackDeadlineSeconds: 10) }
 end
 
-describe command("gcloud --project='#{project_id}' pubsub subscriptions describe push --format=json") do
+describe command("gcloud --project='#{project_id}' pubsub subscriptions describe pushy --format=json") do
   let(:stdout) { JSON.parse(subject.stdout, symbolize_names: true) }
   its(:exit_status) { should be_zero }
-  it { expect(stdout).to include(name: "projects/#{project_id}/subscriptions/push") }
+  it { expect(stdout).to include(name: "projects/#{project_id}/subscriptions/pushy") }
   it { expect(stdout).to include(topic: "projects/#{project_id}/topics/#{topic}") }
   it { expect(stdout).to include(pushConfig: { pushEndpoint: "https://#{project_id}.appspot.com/" }) }
   it { expect(stdout).to include(ackDeadlineSeconds: 20) }

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -15,12 +15,12 @@
 name: cloud-pubsub
 title: Google Cloud Pub/Sub
 version: 0.1.0
-inspec_version: '~> 2.3.24'
+inspec_version: '~> 3.0.64'
 attributes:
   - name: project_id
     type: string
     required: true
-  - name: topic_name
+  - name: topic
     type: string
     required: true
   - name: credentials_file_path


### PR DESCRIPTION
Currently, subscription names and paths are returned using lists. While this works, it makes dynamically selecting the proper subscription when one or more is available a bit more difficult. Since the subscription name _has_ to be provided by the user, it seems natural that the subscription path could also be fetched using the subscription name.

This PR refactors the pubsub outputs to use a map for subscription names and paths instead of the two outputs with lists.