### PR TITLE
Add support for message_retention_duration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,6 @@
 
 locals {
   default_ack_deadline_seconds = 10
-  default_message_retention_duration = "604800s" // One week
 }
 
 resource "google_pubsub_topic" "topic" {
@@ -46,7 +45,7 @@ resource "google_pubsub_subscription" "push_subscriptions" {
   message_retention_duration = lookup(
     var.push_subscriptions[count.index],
     "message_retention_duration",
-    local.default_message_retention_duration,
+    null,
   )
 
   push_config {
@@ -75,7 +74,7 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
   message_retention_duration = lookup(
     var.push_subscriptions[count.index],
     "message_retention_duration",
-    local.default_message_retention_duration,
+    null,
   )
 
   depends_on = [google_pubsub_topic.topic]

--- a/main.tf
+++ b/main.tf
@@ -72,11 +72,10 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     local.default_ack_deadline_seconds,
   )
   message_retention_duration = lookup(
-    var.push_subscriptions[count.index],
+    var.pull_subscriptions[count.index],
     "message_retention_duration",
     null,
   )
 
   depends_on = [google_pubsub_topic.topic]
 }
-

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@
 
 locals {
   default_ack_deadline_seconds = 10
+  default_message_retention_duration = "604800s" // One week
 }
 
 resource "google_pubsub_topic" "topic" {
@@ -42,6 +43,11 @@ resource "google_pubsub_subscription" "push_subscriptions" {
     "ack_deadline_seconds",
     local.default_ack_deadline_seconds,
   )
+  message_retention_duration = lookup(
+    var.push_subscriptions[count.index],
+    "message_retention_duration",
+    local.default_message_retention_duration,
+  )
 
   push_config {
     push_endpoint = var.push_subscriptions[count.index]["push_endpoint"]
@@ -65,6 +71,11 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     var.pull_subscriptions[count.index],
     "ack_deadline_seconds",
     local.default_ack_deadline_seconds,
+  )
+  message_retention_duration = lookup(
+    var.push_subscriptions[count.index],
+    "message_retention_duration",
+    local.default_message_retention_duration,
   )
 
   depends_on = [google_pubsub_topic.topic]


### PR DESCRIPTION
The message_retention_duration attribute is supported by the google_pubsub_subscription resource, but it is not yet exposed through this module.