### PR TITLE
Add support for OIDC service account and audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ module "pubsub" {
 | project\_id | The project ID to manage the Pub/Sub resources | string | n/a | yes |
 | pull\_subscriptions | The list of the pull subscriptions | list(map(string)) | `<list>` | no |
 | push\_subscriptions | The list of the push subscriptions | list(map(string)) | `<list>` | no |
+| oidc\_service\_account | Service account email to be used for generating the OIDC token for push subscriptions (**enables authentication**) | string | `null` | no |
 | topic | The Pub/Sub topic name | string | n/a | yes |
 | topic\_labels | A map of labels to assign to the Pub/Sub topic | map(string) | `<map>` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,15 @@ resource "google_pubsub_subscription" "push_subscriptions" {
     attributes = {
       x-goog-version = lookup(var.push_subscriptions[count.index], "x-goog-version", "v1")
     }
+
+    dynamic "oidc_token" {
+      for_each = [var.oidc_service_account]
+      content {
+        service_account_email = var.oidc_service_account
+        audience = var.oidc_audience
+      }
+    }
+
   }
 
   depends_on = [google_pubsub_topic.topic]
@@ -76,6 +85,5 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     "message_retention_duration",
     null,
   )
-
   depends_on = [google_pubsub_topic.topic]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,15 @@ variable "message_storage_policy" {
   description = "A map of storage policies. Default - inherit from organization's Resource Location Restriction policy."
   default     = {}
 }
+
+variable "oidc_service_account" {
+  type = string
+  description = "Service account email to be used for generating the OIDC token"
+  default = null
+}
+
+variable "oidc_audience" {
+  type = string
+  description = "Audience to be used when generating an OIDC token"
+  default = null
+}


### PR DESCRIPTION
Adds support for the `oidc_token` variables exposed by `google_pubsub_subscription` for push subscriptions