### PR TITLE
Use variable instead of local to define default_ack_deadline_seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ module "pubsub" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | create\_topic | Specify true if you want to create a topic | bool | `"true"` | no |
+| default\_ack\_deadline\_seconds | Set a default acknowledge deadline (in seconds) which will be used if such is not defined by the subscriptions | number | `"10"` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | map | `<map>` | no |
 | project\_id | The project ID to manage the Pub/Sub resources | string | n/a | yes |
 | pull\_subscriptions | The list of the pull subscriptions | list(map(string)) | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-locals {
-  default_ack_deadline_seconds = 10
-}
-
 resource "google_pubsub_topic" "topic" {
   count   = var.create_topic ? 1 : 0
   project = var.project_id
@@ -40,7 +36,7 @@ resource "google_pubsub_subscription" "push_subscriptions" {
   ack_deadline_seconds = lookup(
     var.push_subscriptions[count.index],
     "ack_deadline_seconds",
-    local.default_ack_deadline_seconds,
+    var.default_ack_deadline_seconds,
   )
   message_retention_duration = lookup(
     var.push_subscriptions[count.index],
@@ -69,7 +65,7 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
   ack_deadline_seconds = lookup(
     var.pull_subscriptions[count.index],
     "ack_deadline_seconds",
-    local.default_ack_deadline_seconds,
+    var.default_ack_deadline_seconds,
   )
   message_retention_duration = lookup(
     var.pull_subscriptions[count.index],

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,13 @@ variable "message_storage_policy" {
   description = "A map of storage policies. Default - inherit from organization's Resource Location Restriction policy."
   default     = {}
 }
+
+variable "default_ack_deadline_seconds" {
+  type        = number
+  description = "Set a default acknowledge deadline (in seconds) which will be used if such is not defined by the subscriptions"
+  default     = 10
+  validation {
+    condition = (var.default_ack_deadline_seconds >= 10) && (var.default_ack_deadline_seconds <= 600)
+    error_message = "Must be an integer between 10 to 600"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,5 @@
 
 terraform {
   required_version = ">= 0.12"
+  experiments = [variable_validation]
 }


### PR DESCRIPTION
Currently the `ack_deadline_seconds` is looked up from the subscriptions array. If not defined in the subscriptions array, then a `default_ack_deadline_seconds` is used from the `locals`. However, this default value from the `locals` is not configurable right now. It is fixed to `10`.

Now, if we to have a different `ack_deadline_seconds` for ALL of the subscriptions, we are required to pass it separately into every single subscription block. Instead, we could just define a `default_ack_deadline_seconds` variable value, and then it can save us from having to pass the same `ack_deadline_seconds` into every single subscription block.

Therefore, proposing to use `var.default_ack_deadline_seconds` with a default of `10` (as before) instead of using `local.default_ack_deadline_seconds` which has a fixed value of `10`.