### PR TITLE
feat: Add OIDC token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ module "pubsub" {
       ack_deadline_seconds = 20 // optional
       push_endpoint        = "https://example.com" // required
       x-goog-version       = "v1beta1" // optional
+      oidc_service_account = "sa@example.com" // optional
+      audience             = "example" // optional
     }
   ]
   pull_subscriptions = [

--- a/main.tf
+++ b/main.tf
@@ -57,8 +57,15 @@ resource "google_pubsub_subscription" "push_subscriptions" {
     attributes = {
       x-goog-version = lookup(var.push_subscriptions[count.index], "x-goog-version", "v1")
     }
-  }
 
+    dynamic "oidc_token" {
+      for_each = (lookup(var.push_subscriptions[count.index], "oidc_service_account_email", "") != "") ? [true] : []
+      content {
+        service_account_email = lookup(var.push_subscriptions[count.index], "oidc_service_account_email", "")
+        audience              = lookup(var.push_subscriptions[count.index], "audience", "")
+      }
+    }
+  }
   depends_on = [google_pubsub_topic.topic]
 }
 


### PR DESCRIPTION
Following to the comment in the PR: https://github.com/terraform-google-modules/terraform-google-pubsub/pull/22

This PR adds support for the `oidc_token` config used by `google_pubsub_subscription` for push subscriptions.