### PR TITLE
feat: Add support for dead_letter_policy to subscription resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,23 @@ module "pubsub" {
   project_id         = "my-pubsub-project"
   push_subscriptions = [
     {
-      name                 = "push"   // required
-      ack_deadline_seconds = 20 // optional
-      push_endpoint        = "https://example.com" // required
-      x-goog-version       = "v1beta1" // optional
-      oidc_service_account = "sa@example.com" // optional
-      audience             = "example" // optional
-      expiration_policy    = "1209600s" // optional
+      name                  = "push"   // required
+      ack_deadline_seconds  = 20 // optional
+      push_endpoint         = "https://example.com" // required
+      x-goog-version        = "v1beta1" // optional
+      oidc_service_account  = "sa@example.com" // optional
+      audience              = "example" // optional
+      expiration_policy     = "1209600s" // optional
+      dead_letter_topic     = "example-dl-topic" // optional
+      max_delivery_attempts = 5 // optional
     }
   ]
   pull_subscriptions = [
     {
-      name                 = "pull" // required
-      ack_deadline_seconds = 20 // optional
+      name                  = "pull" // required
+      ack_deadline_seconds  = 20 // optional
+      dead_letter_topic     = "example-dl-topic" // optional
+      max_delivery_attempts = 5 // optional
     }
   ]
 }

--- a/examples/cloudiot/main.tf
+++ b/examples/cloudiot/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.16"
   region  = var.region
 }
 

--- a/examples/kms/main.tf
+++ b/examples/kms/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.16"
   region  = "us-central1"
 }
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.13"
+  version = "~> 3.16"
   region  = "us-central1"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,14 @@ resource "google_pubsub_subscription" "push_subscriptions" {
     }
   }
 
+  dynamic "dead_letter_policy" {
+    for_each = contains(keys(var.push_subscriptions[count.index]), "dead_letter_topic") ? [var.push_subscriptions[count.index].dead_letter_topic] : []
+    content {
+      dead_letter_topic     = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "")
+      max_delivery_attempts = lookup(var.push_subscriptions[count.index], "max_delivery_attempts", "5")
+    }
+  }
+
   push_config {
     push_endpoint = var.push_subscriptions[count.index]["push_endpoint"]
 
@@ -96,6 +104,14 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     for_each = contains(keys(var.pull_subscriptions[count.index]), "expiration_policy") ? [var.pull_subscriptions[count.index].expiration_policy] : []
     content {
       ttl = expiration_policy.value
+    }
+  }
+
+  dynamic "dead_letter_policy" {
+    for_each = contains(keys(var.pull_subscriptions[count.index]), "dead_letter_topic") ? [var.pull_subscriptions[count.index].dead_letter_topic] : []
+    content {
+      dead_letter_topic     = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "")
+      max_delivery_attempts = lookup(var.pull_subscriptions[count.index], "max_delivery_attempts", "5")
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "google_pubsub_subscription" "push_subscriptions" {
   }
 
   dynamic "dead_letter_policy" {
-    for_each = contains(keys(var.push_subscriptions[count.index]), "dead_letter_topic") ? [var.push_subscriptions[count.index].dead_letter_topic] : []
+    for_each = (lookup(var.push_subscriptions[count.index], "dead_letter_topic", "") != "") ? [var.push_subscriptions[count.index].dead_letter_topic] : []
     content {
       dead_letter_topic     = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "")
       max_delivery_attempts = lookup(var.push_subscriptions[count.index], "max_delivery_attempts", "5")
@@ -108,7 +108,7 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
   }
 
   dynamic "dead_letter_policy" {
-    for_each = contains(keys(var.pull_subscriptions[count.index]), "dead_letter_topic") ? [var.pull_subscriptions[count.index].dead_letter_topic] : []
+    for_each = (lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "") != "") ? [var.pull_subscriptions[count.index].dead_letter_topic] : []
     content {
       dead_letter_topic     = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "")
       max_delivery_attempts = lookup(var.pull_subscriptions[count.index], "max_delivery_attempts", "5")


### PR DESCRIPTION
This PR adds the ability to use `dead_letter_policy`, so when a message can't be acknowledged, pub/sub can forward this message to a dead-letter topic.