### PR TITLE
feat: Add iam-bindings to the default pub/sub service account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "google_pubsub_topic_iam_binding" "push_topic_binding" {
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
+  depends_on = [google_pubsub_topic.topic]
 }
 
 resource "google_pubsub_topic_iam_binding" "pull_topic_binding" {
@@ -41,6 +42,7 @@ resource "google_pubsub_topic_iam_binding" "pull_topic_binding" {
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
+  depends_on = [google_pubsub_topic.topic]
 }
 
 resource "google_pubsub_subscription_iam_binding" "pull_subscription_binding" {
@@ -50,6 +52,7 @@ resource "google_pubsub_subscription_iam_binding" "pull_subscription_binding" {
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
+  depends_on = [google_pubsub_topic.topic]
 }
 
 resource "google_pubsub_subscription_iam_binding" "push_subscription_binding" {
@@ -59,6 +62,7 @@ resource "google_pubsub_subscription_iam_binding" "push_subscription_binding" {
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
+  depends_on = [google_pubsub_topic.topic]
 }
 
 resource "google_pubsub_topic" "topic" {

--- a/main.tf
+++ b/main.tf
@@ -26,43 +26,53 @@ locals {
 resource "google_pubsub_topic_iam_binding" "push_topic_binding" {
   count   = var.create_topic ? length(var.push_subscriptions) : 0
   project = var.project_id
-  topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.push_subscriptions[count.index].name}")
+  topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
   role    = "roles/pubsub.publisher"
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
-  depends_on = [google_pubsub_topic.topic]
+  depends_on = [
+    google_pubsub_topic.topic,
+  ]
 }
 
 resource "google_pubsub_topic_iam_binding" "pull_topic_binding" {
   count   = var.create_topic ? length(var.pull_subscriptions) : 0
   project = var.project_id
-  topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.pull_subscriptions[count.index].name}")
+  topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
   role    = "roles/pubsub.publisher"
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
-  depends_on = [google_pubsub_topic.topic]
+  depends_on = [
+    google_pubsub_topic.topic,
+  ]
 }
 
 resource "google_pubsub_subscription_iam_binding" "pull_subscription_binding" {
   count        = var.create_topic ? length(var.pull_subscriptions) : 0
+  project      = var.project_id
   subscription = var.pull_subscriptions[count.index].name
   role         = "roles/pubsub.subscriber"
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
-  depends_on = [google_pubsub_topic.topic]
+  depends_on = [
+    google_pubsub_subscription.pull_subscriptions,
+  ]
 }
 
 resource "google_pubsub_subscription_iam_binding" "push_subscription_binding" {
   count        = var.create_topic ? length(var.push_subscriptions) : 0
+  project      = var.project_id
   subscription = var.push_subscriptions[count.index].name
   role         = "roles/pubsub.subscriber"
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
   ]
-  depends_on = [google_pubsub_topic.topic]
+  depends_on = [
+    google_pubsub_subscription.push_subscriptions,
+  ]
 }
 
 resource "google_pubsub_topic" "topic" {
@@ -128,7 +138,9 @@ resource "google_pubsub_subscription" "push_subscriptions" {
       }
     }
   }
-  depends_on = [google_pubsub_topic.topic]
+  depends_on = [
+    google_pubsub_topic.topic,
+  ]
 }
 
 resource "google_pubsub_subscription" "pull_subscriptions" {
@@ -162,5 +174,7 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     }
   }
 
-  depends_on = [google_pubsub_topic.topic]
+  depends_on = [
+    google_pubsub_topic.topic,
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ locals {
 resource "google_pubsub_topic_iam_binding" "push_topic_binding" {
   count   = var.create_topic ? length(var.push_subscriptions) : 0
   project = var.project_id
-  topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.push_subscriptions[count.index].name}")
   role    = "roles/pubsub.publisher"
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",
@@ -36,7 +36,7 @@ resource "google_pubsub_topic_iam_binding" "push_topic_binding" {
 resource "google_pubsub_topic_iam_binding" "pull_topic_binding" {
   count   = var.create_topic ? length(var.pull_subscriptions) : 0
   project = var.project_id
-  topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.pull_subscriptions[count.index].name}")
   role    = "roles/pubsub.publisher"
   members = [
     "serviceAccount:${local.pubsub_svc_account_email}",

--- a/main.tf
+++ b/main.tf
@@ -23,27 +23,23 @@ locals {
   pubsub_svc_account_email     = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
-resource "google_pubsub_topic_iam_binding" "push_topic_binding" {
+resource "google_pubsub_topic_iam_member" "push_topic_binding" {
   count   = var.create_topic ? length(var.push_subscriptions) : 0
   project = var.project_id
   topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
   role    = "roles/pubsub.publisher"
-  members = [
-    "serviceAccount:${local.pubsub_svc_account_email}",
-  ]
+  member  = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [
     google_pubsub_topic.topic,
   ]
 }
 
-resource "google_pubsub_topic_iam_binding" "pull_topic_binding" {
+resource "google_pubsub_topic_iam_member" "pull_topic_binding" {
   count   = var.create_topic ? length(var.pull_subscriptions) : 0
   project = var.project_id
   topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
   role    = "roles/pubsub.publisher"
-  members = [
-    "serviceAccount:${local.pubsub_svc_account_email}",
-  ]
+  member  = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [
     google_pubsub_topic.topic,
   ]

--- a/main.tf
+++ b/main.tf
@@ -14,8 +14,51 @@
  * limitations under the License.
  */
 
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 locals {
   default_ack_deadline_seconds = 10
+  pubsub_svc_account_email     = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_pubsub_topic_iam_binding" "push_topic_binding" {
+  count   = var.create_topic ? length(var.push_subscriptions) : 0
+  project = var.project_id
+  topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  role    = "roles/pubsub.publisher"
+  members = [
+    "serviceAccount:${local.pubsub_svc_account_email}",
+  ]
+}
+
+resource "google_pubsub_topic_iam_binding" "pull_topic_binding" {
+  count   = var.create_topic ? length(var.pull_subscriptions) : 0
+  project = var.project_id
+  topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  role    = "roles/pubsub.publisher"
+  members = [
+    "serviceAccount:${local.pubsub_svc_account_email}",
+  ]
+}
+
+resource "google_pubsub_subscription_iam_binding" "pull_subscription_binding" {
+  count        = var.create_topic ? length(var.pull_subscriptions) : 0
+  subscription = var.pull_subscriptions[count.index].name
+  role         = "roles/pubsub.subscriber"
+  members = [
+    "serviceAccount:${local.pubsub_svc_account_email}",
+  ]
+}
+
+resource "google_pubsub_subscription_iam_binding" "push_subscription_binding" {
+  count        = var.create_topic ? length(var.push_subscriptions) : 0
+  subscription = var.push_subscriptions[count.index].name
+  role         = "roles/pubsub.subscriber"
+  members = [
+    "serviceAccount:${local.pubsub_svc_account_email}",
+  ]
 }
 
 resource "google_pubsub_topic" "topic" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -17,7 +17,7 @@
 locals {
   int_required_roles = [
     "roles/cloudiot.admin",
-    "roles/pubsub.editor"
+    "roles/pubsub.admin"
   ]
 }
 


### PR DESCRIPTION
This PR adds IAM bindings that will grant Pub/Sub permission to publish messages to the dead-letter topic (publisher role), and acknowledge forwarded messages from the subscription(subscriber role).

terraform DOCS ref:
```
The Cloud Pub/Sub service\naccount associated with the enclosing subscription's parent project (i.e., service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have permission to Publish() to this topic.
```