### PR TITLE
feat: Add SA token creator binding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,15 @@ locals {
   pubsub_svc_account_email     = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "token_creator_binding" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${local.pubsub_svc_account_email}"
+  depends_on = [
+    google_pubsub_subscription.push_subscriptions,
+  ]
+}
+
 resource "google_pubsub_topic_iam_member" "push_topic_binding" {
   count   = var.create_topic ? length(var.push_subscriptions) : 0
   project = var.project_id

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -17,7 +17,8 @@
 locals {
   int_required_roles = [
     "roles/cloudiot.admin",
-    "roles/pubsub.admin"
+    "roles/pubsub.admin",
+    "roles/resourcemanager.projectIamAdmin"
   ]
 }
 


### PR DESCRIPTION
 This PR adds iam_mmeber_binding which is required when you use `push` with oidc_token block.

`You must grant Pub/Sub the permissions needed to create tokens for your service account. Pub/Sub creates and maintains a special service account for your project: service-PROJECT_NUMBER@gcp-sa-pubsub.iam.gserviceaccount.com. This service account needs the Service Account Token Creator role. If you use the Cloud Console to set up the subscription for push authentication, the role is granted automatically.`