### PR TITLE
fix: Remove token creator role binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0](https://www.github.com/terraform-google-modules/terraform-google-pubsub/compare/v1.5.0...v1.6.0) (2020-11-13)
+
+
+### Features
+
+* Add token creator binding for service account ([#37](https://www.github.com/terraform-google-modules/terraform-google-pubsub/issues/37)) ([112607c](https://www.github.com/terraform-google-modules/terraform-google-pubsub/commit/112607cc503d9d884fe66c85d9fc6143ed84ceb5))
+* Adding support for retry_policy.maximum_backoff and retry_policy.minimum_backoff ([#40](https://www.github.com/terraform-google-modules/terraform-google-pubsub/issues/40)) ([4972a25](https://www.github.com/terraform-google-modules/terraform-google-pubsub/commit/4972a25046ba554e622ca27bb735572d31397814))
+* Use non-authoritative iam binding for subscription ([#46](https://www.github.com/terraform-google-modules/terraform-google-pubsub/issues/46)) ([b8390bd](https://www.github.com/terraform-google-modules/terraform-google-pubsub/commit/b8390bda9b445cc44c30482b2c52cc2e533d53d9)), closes [#44](https://www.github.com/terraform-google-modules/terraform-google-pubsub/issues/44)
+
 ## [1.5.0](https://www.github.com/terraform-google-modules/terraform-google-pubsub/compare/v1.4.0...v1.5.0) (2020-09-21)
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a simple usage of the module. Please see also a simple setup provided in
 ```hcl
 module "pubsub" {
   source  = "terraform-google-modules/pubsub/google"
-  version = "~> 1.5"
+  version = "~> 1.6"
 
   topic              = "tf-topic"
   project_id         = "my-pubsub-project"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module "pubsub" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create\_topic | Specify true if you want to create a topic | `bool` | `true` | no |
-| grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA | `bool` | `false` | no |
+| grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA | `bool` | `true` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map` | `{}` | no |
 | project\_id | The project ID to manage the Pub/Sub resources | `string` | n/a | yes |
 | pull\_subscriptions | The list of the pull subscriptions | `list(map(string))` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ module "pubsub" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | create\_topic | Specify true if you want to create a topic | `bool` | `true` | no |
+| grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA | `bool` | `false` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map` | `{}` | no |
 | project\_id | The project ID to manage the Pub/Sub resources | `string` | n/a | yes |
 | pull\_subscriptions | The list of the pull subscriptions | `list(map(string))` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -23,15 +23,6 @@ locals {
   pubsub_svc_account_email     = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
-resource "google_project_iam_member" "token_creator_binding" {
-  project = var.project_id
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${local.pubsub_svc_account_email}"
-  depends_on = [
-    google_pubsub_subscription.push_subscriptions,
-  ]
-}
-
 resource "google_pubsub_topic_iam_member" "push_topic_binding" {
   count   = var.create_topic ? length(var.push_subscriptions) : 0
   project = var.project_id

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,16 @@ locals {
   pubsub_svc_account_email     = "service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "token_creator_binding" {
+  count   = var.grant_token_creator ? 1 : 0
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${local.pubsub_svc_account_email}"
+  depends_on = [
+    google_pubsub_subscription.push_subscriptions,
+  ]
+}
+
 resource "google_pubsub_topic_iam_member" "push_topic_binding" {
   count   = var.create_topic ? length(var.push_subscriptions) : 0
   project = var.project_id

--- a/variables.tf
+++ b/variables.tf
@@ -59,3 +59,9 @@ variable "topic_kms_key_name" {
   description = "The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic."
   default     = null
 }
+
+variable "grant_token_creator" {
+  type        = bool
+  description = "Specify true if you want to add token creator role to the default Pub/Sub SA"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -63,5 +63,5 @@ variable "topic_kms_key_name" {
 variable "grant_token_creator" {
   type        = bool
   description = "Specify true if you want to add token creator role to the default Pub/Sub SA"
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
When you have a push subscription with OIDC enabled, you need to have `roles/iam.serviceAccountTokenCreator` role added to Pub/Sub’s default SA.
But if you would remove one subscription with all its resources it will delete a role as well, but some other subscriptions might still need to use it since there is just one default Pub/Sub service account per project.

This role should be added on the project-factory-module level after you check that the Pub/Sub API is enabled.