### PR TITLE
fix: Use subscription names as the keys instead of numeric indexes

### DIFF
--- a/docs/upgrading_to_v2.0.md
+++ b/docs/upgrading_to_v2.0.md
@@ -9,7 +9,7 @@ The v2.0 release of *terraform-google-pubsub* is a backwards incompatible releas
 ### Pubsub Subscription for_each
 The `google_pubsub_subscription` resource has been updated to use `for_each` instead of `count`. This allows adding/removing subscriptions without causing a diff on unrelated subscriptions.
 
-Updating to this new format requires a state migration. 
+Updating to this new format requires a state migration.
 All `google_pubsub_subscription.pull_subscriptions` and `google_pubsub_subscription.push_subscriptions` resources with numerical indexes in the state need to be moved to resources with named indexes, where each index is the name of the subscription.
 
 For example:

--- a/docs/upgrading_to_v2.0.md
+++ b/docs/upgrading_to_v2.0.md
@@ -1,0 +1,29 @@
+# Upgrading to v2.0
+
+The v2.0 release of *terraform-google-pubsub* is a backwards incompatible release.
+
+## Migration Instructions
+
+
+
+### Pubsub Subscription for_each
+The `google_pubsub_subscription` resource has been updated to use `for_each` instead of `count`. This allows adding/removing subscriptions without causing a diff on unrelated subscriptions.
+
+Updating to this new format requires a state migration. 
+All `google_pubsub_subscription.pull_subscriptions` and `google_pubsub_subscription.push_subscriptions` resources with numerical indexes in the state need to be moved to resources with named indexes, where each index is the name of the subscription.
+
+For example:
+
+```bash
+terraform state mv 'google_pubsub_subscription.pull_subscriptions[0]' 'google_pubsub_subscription.pull_subscriptions["pull-subscription1-name"]'
+terraform state mv 'google_pubsub_subscription.pull_subscriptions[1]' 'google_pubsub_subscription.pull_subscriptions["pull-subscription2-name"]'
+
+terraform state mv 'google_pubsub_subscription.push_subscriptions[0]' 'google_pubsub_subscription.push_subscriptions["push-subscription1-name"]'
+terraform state mv 'google_pubsub_subscription.push_subscriptions[1]' 'google_pubsub_subscription.push_subscriptions["push-subscription2-name"]'
+
+```
+
+### Topic and subscription IAM member
+
+The `google_pubsub_topic_iam_member` and `google_pubsub_subscription_iam_member` resources also has been updated to use `for_each` instead of `count`.
+But recreating these resources with `terraform apply` command instead of state migration is usually fine for most cases.

--- a/docs/upgrading_to_v2.0.md
+++ b/docs/upgrading_to_v2.0.md
@@ -25,5 +25,5 @@ terraform state mv 'google_pubsub_subscription.push_subscriptions[1]' 'google_pu
 
 ### Topic and subscription IAM member
 
-The `google_pubsub_topic_iam_member` and `google_pubsub_subscription_iam_member` resources also has been updated to use `for_each` instead of `count`.
+The `google_pubsub_topic_iam_member` and `google_pubsub_subscription_iam_member` resources also have been updated to use `for_each` instead of `count`.
 But recreating these resources with `terraform apply` command instead of state migration is usually fine for most cases.

--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,10 @@ resource "google_project_iam_member" "token_creator_binding" {
 }
 
 resource "google_pubsub_topic_iam_member" "push_topic_binding" {
-  count   = var.create_topic ? length(var.push_subscriptions) : 0
+  for_each = { for i in var.push_subscriptions : i.name => i if var.create_topic }
+
   project = var.project_id
-  topic   = lookup(var.push_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  topic   = lookup(each.value, "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [
@@ -45,9 +46,10 @@ resource "google_pubsub_topic_iam_member" "push_topic_binding" {
 }
 
 resource "google_pubsub_topic_iam_member" "pull_topic_binding" {
-  count   = var.create_topic ? length(var.pull_subscriptions) : 0
+  for_each = { for i in var.pull_subscriptions : i.name => i if var.create_topic }
+
   project = var.project_id
-  topic   = lookup(var.pull_subscriptions[count.index], "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  topic   = lookup(each.value, "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [
@@ -56,9 +58,10 @@ resource "google_pubsub_topic_iam_member" "pull_topic_binding" {
 }
 
 resource "google_pubsub_subscription_iam_member" "pull_subscription_binding" {
-  count        = var.create_topic ? length(var.pull_subscriptions) : 0
+  for_each = { for i in var.pull_subscriptions : i.name => i if var.create_topic }
+
   project      = var.project_id
-  subscription = var.pull_subscriptions[count.index].name
+  subscription = each.value.name
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [
@@ -67,9 +70,10 @@ resource "google_pubsub_subscription_iam_member" "pull_subscription_binding" {
 }
 
 resource "google_pubsub_subscription_iam_member" "push_subscription_binding" {
-  count        = var.create_topic ? length(var.push_subscriptions) : 0
+  for_each = { for i in var.push_subscriptions : i.name => i if var.create_topic }
+
   project      = var.project_id
-  subscription = var.push_subscriptions[count.index].name
+  subscription = each.value.name
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_project_iam_member" "token_creator_binding" {
 }
 
 resource "google_pubsub_topic_iam_member" "push_topic_binding" {
-  for_each = { for i in var.push_subscriptions : i.name => i if var.create_topic }
+  for_each = var.create_topic ? { for i in var.push_subscriptions : i.name => i } : {}
 
   project = var.project_id
   topic   = lookup(each.value, "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
@@ -46,7 +46,7 @@ resource "google_pubsub_topic_iam_member" "push_topic_binding" {
 }
 
 resource "google_pubsub_topic_iam_member" "pull_topic_binding" {
-  for_each = { for i in var.pull_subscriptions : i.name => i if var.create_topic }
+  for_each = var.create_topic ? { for i in var.pull_subscriptions : i.name => i } : {}
 
   project = var.project_id
   topic   = lookup(each.value, "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
@@ -58,7 +58,7 @@ resource "google_pubsub_topic_iam_member" "pull_topic_binding" {
 }
 
 resource "google_pubsub_subscription_iam_member" "pull_subscription_binding" {
-  for_each = { for i in var.pull_subscriptions : i.name => i if var.create_topic }
+  for_each = var.create_topic ? { for i in var.pull_subscriptions : i.name => i } : {}
 
   project      = var.project_id
   subscription = each.value.name
@@ -70,7 +70,7 @@ resource "google_pubsub_subscription_iam_member" "pull_subscription_binding" {
 }
 
 resource "google_pubsub_subscription_iam_member" "push_subscription_binding" {
-  for_each = { for i in var.push_subscriptions : i.name => i if var.create_topic }
+  for_each = var.create_topic ? { for i in var.push_subscriptions : i.name => i } : {}
 
   project      = var.project_id
   subscription = each.value.name
@@ -97,7 +97,7 @@ resource "google_pubsub_topic" "topic" {
 }
 
 resource "google_pubsub_subscription" "push_subscriptions" {
-  for_each = { for i in var.push_subscriptions : i.name => i if var.create_topic }
+  for_each = var.create_topic ? { for i in var.push_subscriptions : i.name => i } : {}
 
   name    = each.value.name
   topic   = google_pubsub_topic.topic.0.name
@@ -175,7 +175,7 @@ resource "google_pubsub_subscription" "push_subscriptions" {
 }
 
 resource "google_pubsub_subscription" "pull_subscriptions" {
-  for_each = { for i in var.pull_subscriptions : i.name => i if var.create_topic }
+  for_each = var.create_topic ? { for i in var.pull_subscriptions : i.name => i } : {}
 
   name    = each.value.name
   topic   = google_pubsub_topic.topic.0.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,8 +36,8 @@ output "uri" {
 
 output "subscription_names" {
   value = concat(
-    google_pubsub_subscription.push_subscriptions.*.name,
-    google_pubsub_subscription.pull_subscriptions.*.name,
+    values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.name }),
+    values({ for k, v in google_pubsub_subscription.pull_subscriptions : k => v.name }),
   )
 
   description = "The name list of Pub/Sub subscriptions"
@@ -45,8 +45,8 @@ output "subscription_names" {
 
 output "subscription_paths" {
   value = concat(
-    google_pubsub_subscription.push_subscriptions.*.path,
-    google_pubsub_subscription.pull_subscriptions.*.path,
+    values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.path }),
+    values({ for k, v in google_pubsub_subscription.pull_subscriptions : k => v.path }),
   )
 
   description = "The path list of Pub/Sub subscriptions"


### PR DESCRIPTION
This PR fixes https://github.com/terraform-google-modules/terraform-google-pubsub/issues/66 and fixes #26.

As it has breaking changes, renaming `google_pubsub_subscription` resources in the state file is necessary for preventing destroy/recreate subscriptions:
```
terraform state mv 'google_pubsub_subscription.pull_subscriptions[0]' 'google_pubsub_subscription.pull_subscriptions["subscription1-name"]'
terraform state mv 'google_pubsub_subscription.pull_subscriptions[1]' 'google_pubsub_subscription.pull_subscriptions["subscription2-name"]'

```