### PR TITLE
feat: Grant pull subscription permissions for external service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ module "pubsub" {
   ]
   pull_subscriptions = [
     {
-      name                    = "pull"                                               // required
-      ack_deadline_seconds    = 20                                                   // optional
-      dead_letter_topic       = "projects/my-pubsub-project/topics/example-dl-topic" // optional
-      max_delivery_attempts   = 5                                                    // optional
-      maximum_backoff         = "600s"                                               // optional
-      minimum_backoff         = "300s"                                               // optional
-      filter                  = "attributes.domain = \"com\""                        // optional
-      enable_message_ordering = true                                                 // optional
+      name                        = "pull"                                               // required
+      ack_deadline_seconds        = 20                                                   // optional
+      dead_letter_topic           = "projects/my-pubsub-project/topics/example-dl-topic" // optional
+      max_delivery_attempts       = 5                                                    // optional
+      maximum_backoff             = "600s"                                               // optional
+      minimum_backoff             = "300s"                                               // optional
+      filter                      = "attributes.domain = \"com\""                        // optional
+      enable_message_ordering     = true                                                 // optional
+      service_account             = "service2@project2.iam.gserviceaccount.com"          // optional
+      service_account_viewer_role = true                                                 // optional
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -38,16 +38,15 @@ module "pubsub" {
   ]
   pull_subscriptions = [
     {
-      name                        = "pull"                                               // required
-      ack_deadline_seconds        = 20                                                   // optional
-      dead_letter_topic           = "projects/my-pubsub-project/topics/example-dl-topic" // optional
-      max_delivery_attempts       = 5                                                    // optional
-      maximum_backoff             = "600s"                                               // optional
-      minimum_backoff             = "300s"                                               // optional
-      filter                      = "attributes.domain = \"com\""                        // optional
-      enable_message_ordering     = true                                                 // optional
-      service_account             = "service2@project2.iam.gserviceaccount.com"          // optional
-      service_account_viewer_role = true                                                 // optional
+      name                    = "pull"                                               // required
+      ack_deadline_seconds    = 20                                                   // optional
+      dead_letter_topic       = "projects/my-pubsub-project/topics/example-dl-topic" // optional
+      max_delivery_attempts   = 5                                                    // optional
+      maximum_backoff         = "600s"                                               // optional
+      minimum_backoff         = "300s"                                               // optional
+      filter                  = "attributes.domain = \"com\""                        // optional
+      enable_message_ordering = true                                                 // optional
+      service_account         = "service2@project2.iam.gserviceaccount.com"          // optional
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -235,9 +235,8 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
   ]
 }
 
-
-resource "google_pubsub_subscription_iam_member" "pull_subscription_sa_binding" {
-  for_each = { for i in var.pull_subscriptions : i.name => i if(var.create_topic && lookup(i, "service_account", null) != null) }
+resource "google_pubsub_subscription_iam_member" "pull_subscription_sa_binding_subscriber" {
+  for_each = var.create_topic ? { for i in var.pull_subscriptions : i.name => i if lookup(i, "service_account", null) != null } : {}
 
   project      = var.project_id
   subscription = each.value.name
@@ -249,7 +248,7 @@ resource "google_pubsub_subscription_iam_member" "pull_subscription_sa_binding" 
 }
 
 resource "google_pubsub_subscription_iam_member" "pull_subscription_sa_binding_viewer" {
-  for_each = { for i in var.pull_subscriptions : i.name => i if(var.create_topic && lookup(i, "service_account_viewer_role", null) == "true") }
+  for_each = var.create_topic ? { for i in var.pull_subscriptions : i.name => i if lookup(i, "service_account", null) != null } : {}
 
   project      = var.project_id
   subscription = each.value.name

--- a/main.tf
+++ b/main.tf
@@ -228,3 +228,28 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
     google_pubsub_topic.topic,
   ]
 }
+
+
+resource "google_pubsub_subscription_iam_member" "pull_subscription_sa_binding" {
+  for_each = { for i in var.pull_subscriptions : i.name => i if(var.create_topic && lookup(i, "service_account", null) != null) }
+
+  project      = var.project_id
+  subscription = each.value.name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${each.value.service_account}"
+  depends_on = [
+    google_pubsub_subscription.pull_subscriptions,
+  ]
+}
+
+resource "google_pubsub_subscription_iam_member" "pull_subscription_sa_binding_viewer" {
+  for_each = { for i in var.pull_subscriptions : i.name => i if(var.create_topic && lookup(i, "service_account_viewer_role", null) == "true") }
+
+  project      = var.project_id
+  subscription = each.value.name
+  role         = "roles/pubsub.viewer"
+  member       = "serviceAccount:${each.value.service_account}"
+  depends_on = [
+    google_pubsub_subscription.pull_subscriptions,
+  ]
+}


### PR DESCRIPTION
It is useful to grant permissions for the service account that will subscribe to that pull_subscription just after creating it.
Especially if granting access to the service account from another project.

Also as Kafka-connect needs additional `roles/pubsub.viewer` role for subscribing to the topic, `service_account_viewer_role` switch is provided.