### PR TITLE
chore: Change output reference

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -45,8 +45,8 @@ output "subscription_names" {
 
 output "subscription_paths" {
   value = concat(
-    values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.path }),
-    values({ for k, v in google_pubsub_subscription.pull_subscriptions : k => v.path }),
+    values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.id }),
+    values({ for k, v in google_pubsub_subscription.pull_subscriptions : k => v.id }),
   )
 
   description = "The path list of Pub/Sub subscriptions"


### PR DESCRIPTION
Since version 4.0.0 of google provider there is no `path` field.
Release: https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.0.0
 - pubsub: removed path field from google_pubsub_subscription ([#10424](https://github.com/hashicorp/terraform-provider-google/pull/10424))
 
 Error:
 ```╷
╷
│ Error: Unsupported attribute
│
│   on outputs.tf line 48, in output "subscription_paths":
│   48:     values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.path }),
│
│ This object does not have an attribute named "path".
╵
ERRO[0006] 1 error occurred:
	* exit status 1
```

