### PR TITLE
Add higher version support

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 3.79, < 5.0"
     }
   }
 


### PR DESCRIPTION
This is with related to the issue `https://github.com/terraform-google-modules/terraform-google-pubsub/issues/86`

Remove other references of lower version of the provider specified in the module