### PR TITLE
feat!: Add the ability to set the message_retention_duration on a PubSub topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,19 @@ module "pubsub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_subscriptions | Specify true if you want to create subscriptions | `bool` | `true` | no |
-| create\_topic | Specify true if you want to create a topic | `bool` | `true` | no |
-| grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA | `bool` | `true` | no |
+| create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
+| create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
+| grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA. | `bool` | `true` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map(any)` | `{}` | no |
-| project\_id | The project ID to manage the Pub/Sub resources | `string` | n/a | yes |
-| pull\_subscriptions | The list of the pull subscriptions | `list(map(string))` | `[]` | no |
-| push\_subscriptions | The list of the push subscriptions | `list(map(string))` | `[]` | no |
-| schema | Schema for the topic | <pre>object({<br>    name       = string<br>    type       = string<br>    definition = string<br>    encoding   = string<br>  })</pre> | `null` | no |
-| subscription\_labels | A map of labels to assign to every Pub/Sub subscription | `map(string)` | `{}` | no |
-| topic | The Pub/Sub topic name | `string` | n/a | yes |
+| project\_id | The project ID to manage the Pub/Sub resources. | `string` | n/a | yes |
+| pull\_subscriptions | The list of the pull subscriptions. | `list(map(string))` | `[]` | no |
+| push\_subscriptions | The list of the push subscriptions. | `list(map(string))` | `[]` | no |
+| schema | Schema for the topic. | <pre>object({<br>    name       = string<br>    type       = string<br>    definition = string<br>    encoding   = string<br>  })</pre> | `null` | no |
+| subscription\_labels | A map of labels to assign to every Pub/Sub subscription. | `map(string)` | `{}` | no |
+| topic | The Pub/Sub topic name. | `string` | n/a | yes |
 | topic\_kms\_key\_name | The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic. | `string` | `null` | no |
-| topic\_labels | A map of labels to assign to the Pub/Sub topic | `map(string)` | `{}` | no |
+| topic\_labels | A map of labels to assign to the Pub/Sub topic. | `map(string)` | `{}` | no |
+| topic\_message\_retention\_duration | The minimum duration in seconds to retain a message after it is published to the topic. | `string` | `null` | no |
 
 ## Outputs
 

--- a/examples/cloudiot/versions.tf
+++ b/examples/cloudiot/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1.0"
+      version = "~> 4.1"
     }
     tls = {
       source = "hashicorp/tls"

--- a/examples/cloudiot/versions.tf
+++ b/examples/cloudiot/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 4.1.0"
     }
     tls = {
       source = "hashicorp/tls"

--- a/examples/cloudiot/versions.tf
+++ b/examples/cloudiot/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1"
+      version = "~> 4.1.0"
     }
     tls = {
       source = "hashicorp/tls"

--- a/examples/kms/versions.tf
+++ b/examples/kms/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1.0"
+      version = "~> 4.1"
     }
   }
   required_version = ">= 0.13"

--- a/examples/kms/versions.tf
+++ b/examples/kms/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1"
+      version = "~> 4.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/examples/kms/versions.tf
+++ b/examples/kms/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 4.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1.0"
+      version = "~> 4.1"
     }
   }
   required_version = ">= 0.13"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1"
+      version = "~> 4.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 4.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/examples/subscriptions_only/versions.tf
+++ b/examples/subscriptions_only/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1.0"
+      version = "~> 4.1"
     }
   }
   required_version = ">= 0.13"

--- a/examples/subscriptions_only/versions.tf
+++ b/examples/subscriptions_only/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1"
+      version = "~> 4.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/examples/subscriptions_only/versions.tf
+++ b/examples/subscriptions_only/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 4.1.0"
     }
   }
   required_version = ">= 0.13"

--- a/main.tf
+++ b/main.tf
@@ -91,11 +91,12 @@ resource "google_pubsub_subscription_iam_member" "push_subscription_binding" {
 }
 
 resource "google_pubsub_topic" "topic" {
-  count        = var.create_topic ? 1 : 0
-  project      = var.project_id
-  name         = var.topic
-  labels       = var.topic_labels
-  kms_key_name = var.topic_kms_key_name
+  count                      = var.create_topic ? 1 : 0
+  project                    = var.project_id
+  name                       = var.topic
+  labels                     = var.topic_labels
+  kms_key_name               = var.topic_kms_key_name
+  message_retention_duration = var.topic_message_retention_duration
 
   dynamic "message_storage_policy" {
     for_each = var.message_storage_policy

--- a/modules/cloudiot/versions.tf
+++ b/modules/cloudiot/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 4.1, < 5.0"
     }
   }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project-ci-int-pubsub" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 10.0"
+  version = "~> 13.0"
 
   name              = "ci-int-pubsub"
   random_project_id = true

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1.0"
+      version = "~> 4.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.1.0"
+      version = "~> 4.1"
     }
     null = {
       source = "hashicorp/null"

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.53.0"
+      version = "~> 4.1.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.53.0"
+      version = "~> 4.1.0"
     }
     null = {
       source = "hashicorp/null"

--- a/variables.tf
+++ b/variables.tf
@@ -16,47 +16,53 @@
 
 variable "project_id" {
   type        = string
-  description = "The project ID to manage the Pub/Sub resources"
+  description = "The project ID to manage the Pub/Sub resources."
 }
 
 variable "topic" {
   type        = string
-  description = "The Pub/Sub topic name"
+  description = "The Pub/Sub topic name."
 }
 
 variable "create_topic" {
   type        = bool
-  description = "Specify true if you want to create a topic"
+  description = "Specify true if you want to create a topic."
   default     = true
 }
 
 variable "create_subscriptions" {
   type        = bool
-  description = "Specify true if you want to create subscriptions"
+  description = "Specify true if you want to create subscriptions."
   default     = true
 }
 variable "topic_labels" {
   type        = map(string)
-  description = "A map of labels to assign to the Pub/Sub topic"
+  description = "A map of labels to assign to the Pub/Sub topic."
   default     = {}
 }
 
 variable "push_subscriptions" {
   type        = list(map(string))
-  description = "The list of the push subscriptions"
+  description = "The list of the push subscriptions."
   default     = []
 }
 
 variable "pull_subscriptions" {
   type        = list(map(string))
-  description = "The list of the pull subscriptions"
+  description = "The list of the pull subscriptions."
   default     = []
 }
 
 variable "subscription_labels" {
   type        = map(string)
-  description = "A map of labels to assign to every Pub/Sub subscription"
+  description = "A map of labels to assign to every Pub/Sub subscription."
   default     = {}
+}
+
+variable "topic_message_retention_duration" {
+  type        = string
+  description = "The minimum duration in seconds to retain a message after it is published to the topic."
+  default     = null
 }
 
 variable "message_storage_policy" {
@@ -73,7 +79,7 @@ variable "topic_kms_key_name" {
 
 variable "grant_token_creator" {
   type        = bool
-  description = "Specify true if you want to add token creator role to the default Pub/Sub SA"
+  description = "Specify true if you want to add token creator role to the default Pub/Sub SA."
   default     = true
 }
 
@@ -84,6 +90,6 @@ variable "schema" {
     definition = string
     encoding   = string
   })
-  description = "Schema for the topic"
+  description = "Schema for the topic."
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 4.1, < 5.0"
     }
   }
 


### PR DESCRIPTION
Already supported on the google_pubsub_topic resource, so just passing through the variable from the tf module terraform-google-pubsub. Argument docs: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic#message_retention_duration

Setting the value to null results in no retention policy being set as the default.

Fixes: https://github.com/terraform-google-modules/terraform-google-pubsub/issues/92