### PR TITLE
chore: update for compatibilty with hashicorp/tls v4

### DIFF
--- a/examples/cloudiot/main.tf
+++ b/examples/cloudiot/main.tf
@@ -25,7 +25,6 @@ resource "tls_private_key" "private_keys" {
 
 resource "tls_self_signed_cert" "certs" {
   count           = 2
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.private_keys[count.index].private_key_pem
   subject {
     common_name  = "example.com"


### PR DESCRIPTION
* `key_algorithm` is read only in hashicorp/tls v4+