### PR TITLE
fix: Add_enable_exactly_once_delivery_on_a_PubSub_subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ module "pubsub" {
       maximum_backoff            = "600s"                                               // optional
       minimum_backoff            = "300s"                                               // optional
       filter                     = "attributes.domain = \"com\""                        // optional
-      enable_message_ordering    = true                                                 // optional
     }
   ]
   pull_subscriptions = [
     {
-      name                    = "pull"                                               // required
-      ack_deadline_seconds    = 20                                                   // optional
-      dead_letter_topic       = "projects/my-pubsub-project/topics/example-dl-topic" // optional
-      max_delivery_attempts   = 5                                                    // optional
-      maximum_backoff         = "600s"                                               // optional
-      minimum_backoff         = "300s"                                               // optional
-      filter                  = "attributes.domain = \"com\""                        // optional
-      enable_message_ordering = true                                                 // optional
-      service_account         = "service2@project2.iam.gserviceaccount.com"          // optional
+      name                         = "pull"                                               // required
+      ack_deadline_seconds         = 20                                                   // optional
+      dead_letter_topic            = "projects/my-pubsub-project/topics/example-dl-topic" // optional
+      max_delivery_attempts        = 5                                                    // optional
+      maximum_backoff              = "600s"                                               // optional
+      minimum_backoff              = "300s"                                               // optional
+      filter                       = "attributes.domain = \"com\""                        // optional
+      enable_message_ordering      = true                                                 // optional
+      service_account              = "service2@project2.iam.gserviceaccount.com"          // optional
+      enable_exactly_once_delivery = true                                                 // optional
     }
   ]
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -32,6 +32,7 @@ module "pubsub" {
     {
       name                 = "pull"
       ack_deadline_seconds = 10
+      enable_exactly_once_delivery = true
     },
   ]
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -30,8 +30,8 @@ module "pubsub" {
 
   pull_subscriptions = [
     {
-      name                 = "pull"
-      ack_deadline_seconds = 10
+      name                         = "pull"
+      ack_deadline_seconds         = 10
       enable_exactly_once_delivery = true
     },
   ]

--- a/main.tf
+++ b/main.tf
@@ -191,10 +191,10 @@ resource "google_pubsub_subscription" "push_subscriptions" {
 resource "google_pubsub_subscription" "pull_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.pull_subscriptions : i.name => i } : {}
 
-  name                         = each.value.name
-  topic                        = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
-  project                      = var.project_id
-  labels                       = var.subscription_labels
+  name    = each.value.name
+  topic   = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
+  project = var.project_id
+  labels  = var.subscription_labels
   enable_exactly_once_delivery = lookup(
     each.value,
     "enable_exactly_once_delivery",

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,11 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
   topic                        = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
   project                      = var.project_id
   labels                       = var.subscription_labels
-  enable_exactly_once_delivery = var.enable_exactly_once_delivery
+  enable_exactly_once_delivery = lookup(
+    each.value,
+    "enable_exactly_once_delivery",
+    false,
+  )
   ack_deadline_seconds = lookup(
     each.value,
     "ack_deadline_seconds",

--- a/main.tf
+++ b/main.tf
@@ -118,11 +118,10 @@ resource "google_pubsub_topic" "topic" {
 resource "google_pubsub_subscription" "push_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.push_subscriptions : i.name => i } : {}
 
-  name                         = each.value.name
-  topic                        = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
-  project                      = var.project_id
-  labels                       = var.subscription_labels
-  enable_exactly_once_delivery = var.enable_exactly_once_delivery
+  name    = each.value.name
+  topic   = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
+  project = var.project_id
+  labels  = var.subscription_labels
   ack_deadline_seconds = lookup(
     each.value,
     "ack_deadline_seconds",
@@ -141,11 +140,6 @@ resource "google_pubsub_subscription" "push_subscriptions" {
   filter = lookup(
     each.value,
     "filter",
-    null,
-  )
-  enable_message_ordering = lookup(
-    each.value,
-    "enable_message_ordering",
     null,
   )
   dynamic "expiration_policy" {
@@ -197,10 +191,11 @@ resource "google_pubsub_subscription" "push_subscriptions" {
 resource "google_pubsub_subscription" "pull_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.pull_subscriptions : i.name => i } : {}
 
-  name    = each.value.name
-  topic   = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
-  project = var.project_id
-  labels  = var.subscription_labels
+  name                         = each.value.name
+  topic                        = var.create_topic ? google_pubsub_topic.topic.0.name : var.topic
+  project                      = var.project_id
+  labels                       = var.subscription_labels
+  enable_exactly_once_delivery = var.enable_exactly_once_delivery
   ack_deadline_seconds = lookup(
     each.value,
     "ack_deadline_seconds",

--- a/test/integration/simple/simple_test.go
+++ b/test/integration/simple/simple_test.go
@@ -40,7 +40,7 @@ func TestSimple(t *testing.T) {
 		assert.Equal(fmt.Sprintf("projects/%s/subscriptions/pull", projectId), op.Get("name").String(), "has expected name")
 		assert.Equal(fmt.Sprintf("projects/%s/topics/cft-tf-pubsub-topic", projectId), op.Get("topic").String(), "has expected topic")
 		assert.Equal("10", op.Get("ackDeadlineSeconds").String(), "has expected ackDeadlineSeconds")
-		assert.Equal(true, op.Get("enable_exactly_once_delivery").Bool(), "has expected enable_exactly_once_delivery")
+		assert.Equal(true, op.Get("enableExactlyOnceDelivery").Bool(), "has expected enable_exactly_once_delivery")
 
 		op = gcloud.Runf(t, "pubsub subscriptions describe push --project=%s", projectId)
 		assert.Equal(fmt.Sprintf("projects/%s/subscriptions/push", projectId), op.Get("name").String(), "has expected name")

--- a/test/integration/simple/simple_test.go
+++ b/test/integration/simple/simple_test.go
@@ -40,6 +40,7 @@ func TestSimple(t *testing.T) {
 		assert.Equal(fmt.Sprintf("projects/%s/subscriptions/pull", projectId), op.Get("name").String(), "has expected name")
 		assert.Equal(fmt.Sprintf("projects/%s/topics/cft-tf-pubsub-topic", projectId), op.Get("topic").String(), "has expected topic")
 		assert.Equal("10", op.Get("ackDeadlineSeconds").String(), "has expected ackDeadlineSeconds")
+		assert.Equal(true, op.Get("enable_exactly_once_delivery").Bool(), "has expected enable_exactly_once_delivery")
 
 		op = gcloud.Runf(t, "pubsub subscriptions describe push --project=%s", projectId)
 		assert.Equal(fmt.Sprintf("projects/%s/subscriptions/push", projectId), op.Get("name").String(), "has expected name")


### PR DESCRIPTION
Hello, this 2 features have been remove from push subscriptions **_enable_message_ordering_** and **_enable_exactly_once_delivery_** they are only available now in pull susbcriptions only. @apeabody 