### PR TITLE
feat!: :sparkles: added bigquery subcription capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ module "pubsub" {
       service_account              = "service2@project2.iam.gserviceaccount.com"          // optional
       enable_exactly_once_delivery = true                                                 // optional
     }
+  bigquery_subscriptions = [
+    {
+      name                = "bigquery"              // required
+      table               = "project.dataset.table" // required
+      use_topic_schema    = true                    // optional
+      write_metadata      = false                   // optional
+      drop_unknown_fields = false                   // optional
+    }
   ]
 }
 ```
@@ -58,6 +66,7 @@ module "pubsub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| bigquery\_subscriptions | The list of the bigquery push subscriptions. | `list(map(string))` | `[]` | no |
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
 | grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA. | `bool` | `true` | no |

--- a/examples/bigquery/README.md
+++ b/examples/bigquery/README.md
@@ -1,0 +1,35 @@
+# Bigquery Example
+
+This example illustrates how to use the `pubsub` module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The project ID to manage the Pub/Sub resources | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| project\_id | The project ID |
+| topic\_labels | The labels of the Pub/Sub topic created |
+| topic\_name | The name of the Pub/Sub topic created |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+The following sections describe the requirements which must be met in
+order to invoke this example. The requirements of the
+[root module][root-module-requirements] must be met.
+
+## Usage
+
+To provision this example, populate `terraform.tfvars` with the [required variables](#inputs) and run the following commands within
+this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/bigquery/main.tf
+++ b/examples/bigquery/main.tf
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  region = "europe-west1"
+}
+
+module "pubsub" {
+  source     = "../../"
+  project_id = var.project_id
+  topic      = "cft-tf-pubsub-topic"
+  topic_labels = {
+    foo_label = "foo_value"
+    bar_label = "bar_value"
+  }
+
+  bigquery_subscriptions = [
+    {
+      name  = "example_subscription"
+      table = "${var.project_id}:example_dataset.example_table"
+    },
+  ]
+
+  depends_on = [
+    google_bigquery_table.test
+  ]
+
+}
+
+resource "google_bigquery_dataset" "test" {
+  project    = var.project_id
+  dataset_id = "example_dataset"
+  location   = "europe-west1"
+}
+
+resource "google_bigquery_table" "test" {
+  project             = var.project_id
+  deletion_protection = false
+  table_id            = "example_table"
+  dataset_id          = google_bigquery_dataset.test.dataset_id
+
+  schema = <<EOF
+[
+  {
+    "name": "data",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The data"
+  }
+]
+EOF
+}

--- a/examples/bigquery/main.tf
+++ b/examples/bigquery/main.tf
@@ -21,7 +21,7 @@ provider "google" {
 module "pubsub" {
   source     = "../../"
   project_id = var.project_id
-  topic      = "cft-tf-pubsub-topic"
+  topic      = "cft-tf-pubsub-topic-bigquery"
   topic_labels = {
     foo_label = "foo_value"
     bar_label = "bar_value"

--- a/examples/bigquery/outputs.tf
+++ b/examples/bigquery/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,17 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = ">= 0.13"
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 4.23"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.23"
-    }
-    null = {
-      source = "hashicorp/null"
-    }
-    random = {
-      source = "hashicorp/random"
-    }
-  }
+output "project_id" {
+  value       = var.project_id
+  description = "The project ID"
 }
 
-provider "google" {
+output "topic_name" {
+  value       = module.pubsub.topic
+  description = "The name of the Pub/Sub topic created"
 }
 
-provider "google-beta" {
+output "topic_labels" {
+  value       = module.pubsub.topic_labels
+  description = "The labels of the Pub/Sub topic created"
 }

--- a/examples/bigquery/variables.tf
+++ b/examples/bigquery/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,28 +14,7 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = ">= 0.13"
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 4.23"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.23"
-    }
-    null = {
-      source = "hashicorp/null"
-    }
-    random = {
-      source = "hashicorp/random"
-    }
-  }
-}
-
-provider "google" {
-}
-
-provider "google-beta" {
+variable "project_id" {
+  type        = string
+  description = "The project ID to manage the Pub/Sub resources"
 }

--- a/examples/bigquery/versions.tf
+++ b/examples/bigquery/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,27 +15,11 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     google = {
       source  = "hashicorp/google"
       version = "~> 4.23"
     }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.23"
-    }
-    null = {
-      source = "hashicorp/null"
-    }
-    random = {
-      source = "hashicorp/random"
-    }
   }
-}
-
-provider "google" {
-}
-
-provider "google-beta" {
+  required_version = ">= 0.13"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,6 +38,7 @@ output "subscription_names" {
   value = concat(
     values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.name }),
     values({ for k, v in google_pubsub_subscription.pull_subscriptions : k => v.name }),
+    values({ for k, v in google_pubsub_subscription.bigquery_subscriptions : k => v.name }),
   )
 
   description = "The name list of Pub/Sub subscriptions"
@@ -47,6 +48,7 @@ output "subscription_paths" {
   value = concat(
     values({ for k, v in google_pubsub_subscription.push_subscriptions : k => v.id }),
     values({ for k, v in google_pubsub_subscription.pull_subscriptions : k => v.id }),
+    values({ for k, v in google_pubsub_subscription.bigquery_subscriptions : k => v.name }),
   )
 
   description = "The path list of Pub/Sub subscriptions"

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -18,7 +18,8 @@ locals {
   int_required_roles = [
     "roles/cloudiot.admin",
     "roles/pubsub.admin",
-    "roles/resourcemanager.projectIamAdmin"
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/bigquery.admin"
   ]
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -28,6 +28,7 @@ module "project-ci-int-pubsub" {
     "cloudiot.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "pubsub.googleapis.com",
-    "serviceusage.googleapis.com"
+    "serviceusage.googleapis.com",
+    "bigquery.googleapis.com",
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "pull_subscriptions" {
   default     = []
 }
 
+variable "bigquery_subscriptions" {
+  type        = list(map(string))
+  description = "The list of the bigquery push subscriptions."
+  default     = []
+}
+
 variable "subscription_labels" {
   type        = map(string)
   description = "A map of labels to assign to every Pub/Sub subscription."

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.17, < 5.0"
+      version = ">= 4.32, < 5.0"
     }
   }
 


### PR DESCRIPTION
Hi! I wanted to integrate the recently released push to bigquery functionality from google provider 4.32.

I tested as thoroughly as possible on our dev setup, i have to say though i was not able to run the kitchen tests, i can't follow the instructions to the letter give some accounts and privileges constraint that i have. I tried to run it against an already existing project but i was not able to, maybe you can help with that.

Thanks for the consideration, any feedback is highly appreciated