### PR TITLE
fix: Generate the topic name if dead_letter_topic is empty

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_pubsub_topic_iam_member" "push_topic_binding" {
   for_each = var.create_topic ? { for i in var.push_subscriptions : i.name => i } : {}
 
   project = var.project_id
-  topic   = lookup(each.value, "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  topic   = (lookup(each.value, "dead_letter_topic", "") != "") ? each.value.dead_letter_topic : "projects/${var.project_id}/topics/${var.topic}"
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [
@@ -58,7 +58,7 @@ resource "google_pubsub_topic_iam_member" "pull_topic_binding" {
   for_each = var.create_topic ? { for i in var.pull_subscriptions : i.name => i } : {}
 
   project = var.project_id
-  topic   = lookup(each.value, "dead_letter_topic", "projects/${var.project_id}/topics/${var.topic}")
+  topic   = (lookup(each.value, "dead_letter_topic", "") != "") ? each.value.dead_letter_topic : "projects/${var.project_id}/topics/${var.topic}"
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"
   depends_on = [


### PR DESCRIPTION
Hey @morgante I had the same error as discussed in #58 and I managed to fix by adding a condition (inspired by:)
https://github.com/terraform-google-modules/terraform-google-pubsub/blob/e15c806db916d342eb02671901b8919c345cf104/main.tf#L237
I had the error because I am using TF v1.3.0 with optional variables set to `""` if not provided.

We also could do something like the following, to handle both `null` and `""` values:
```terraform
  topic   = coalesce(try(each.value.dead_letter_topic, null), "projects/${var.project_id}/topics/${var.topic}")
```

Signed-off-by: Baptiste Roux <baptiste.roux@skale-5.com>


Fix #58 