### PR TITLE
feat: Add new Pub Sub subscription for Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ module "pubsub" {
       drop_unknown_fields = false                   // optional
     }
   ]
+  cloud_storage_subscriptions = [
+    {
+      name                    = "cloud_storage"                          // required
+      bucket                  = google_storage_bucket.bucket-test.0.name // required
+      filename_prefix         = "test-"                                  // optional
+      filename_suffix         = "-ps"                                    // optional
+      max_duration            = "60s"                                    // optional
+      max_bytes               = 1024                                     // optional
+    }
+  ]
 }
 ```
 
@@ -75,6 +85,8 @@ module "pubsub" {
 | project\_id | The project ID to manage the Pub/Sub resources. | `string` | n/a | yes |
 | pull\_subscriptions | The list of the pull subscriptions. | `list(map(string))` | `[]` | no |
 | push\_subscriptions | The list of the push subscriptions. | `list(map(string))` | `[]` | no |
+| bigquery_subscriptions | The list of the bigquery subscriptions. | `list(map(string))` | `[]` | no |
+| cloud_storage_subscriptions | The list of the cloud storage subscriptions. | `list(map(string))` | `[]` | no |
 | schema | Schema for the topic. | <pre>object({<br>    name       = string<br>    type       = string<br>    definition = string<br>    encoding   = string<br>  })</pre> | `null` | no |
 | subscription\_labels | A map of labels to assign to every Pub/Sub subscription. | `map(string)` | `{}` | no |
 | topic | The Pub/Sub topic name. | `string` | n/a | yes |

--- a/examples/cloud_storage/README.md
+++ b/examples/cloud_storage/README.md
@@ -1,0 +1,35 @@
+# Bigquery Example
+
+This example illustrates how to use the `pubsub` module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The project ID to manage the Pub/Sub resources | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| project\_id | The project ID |
+| topic\_labels | The labels of the Pub/Sub topic created |
+| topic\_name | The name of the Pub/Sub topic created |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+The following sections describe the requirements which must be met in
+order to invoke this example. The requirements of the
+[root module][root-module-requirements] must be met.
+
+## Usage
+
+To provision this example, populate `terraform.tfvars` with the [required variables](#inputs) and run the following commands within
+this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/cloud_storage/README.md
+++ b/examples/cloud_storage/README.md
@@ -1,4 +1,4 @@
-# Bigquery Example
+# Cloud Storage Example
 
 This example illustrates how to use the `pubsub` module.
 

--- a/examples/cloud_storage/main.tf
+++ b/examples/cloud_storage/main.tf
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+provider "google" {
+  region = "europe-west1"
+}
+
+module "pubsub" {
+  source     = "../../"
+  project_id = var.project_id
+  topic      = "tf-pub-sub-topic-cloud-storage"
+  topic_labels = {
+    foo_label = "foo_value"
+    bar_label = "bar_value"
+  }
+
+  cloud_storage_subscriptions = [
+    {
+      name            = "cloud_storage"
+      bucket          = google_storage_bucket.bucket-test[0].name
+      filename_prefix = "test-"
+      filename_suffix = "-ps"
+      max_duration    = "60s"
+      max_bytes       = 1024
+    }
+  ]
+
+  depends_on = [
+    google_storage_bucket.bucket-test
+  ]
+}
+
+resource "google_storage_bucket" "bucket-test" {
+  name                        = "testps-bucket"
+  location                    = "EU"
+  uniform_bucket_level_access = true
+  force_destroy               = true
+}

--- a/examples/cloud_storage/outputs.tf
+++ b/examples/cloud_storage/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = var.project_id
+  description = "The project ID"
+}
+
+output "topic_name" {
+  value       = module.pubsub.topic
+  description = "The name of the Pub/Sub topic created"
+}
+
+output "topic_labels" {
+  value       = module.pubsub.topic_labels
+  description = "The labels of the Pub/Sub topic created"
+}

--- a/examples/cloud_storage/variables.tf
+++ b/examples/cloud_storage/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The project ID to manage the Pub/Sub resources"
+}

--- a/examples/cloud_storage/versions.tf
+++ b/examples/cloud_storage/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.23"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "bigquery_subscriptions" {
   default     = []
 }
 
+variable "cloud_storage_subscriptions" {
+  type        = list(map(string))
+  description = "The list of the cloud storage push subscriptions."
+  default     = []
+}
+
 variable "subscription_labels" {
   type        = map(string)
   description = "A map of labels to assign to every Pub/Sub subscription."


### PR DESCRIPTION
The module is extended with the Pub Sub subscription for Cloud Storage and added new dedicated example is now available [https://cloud.google.com/pubsub/docs/cloudstorage](https://cloud.google.com/pubsub/docs/cloudstorage )