### PR TITLE
feat: make granting service agent bigquery roles optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ module "pubsub" {
 | cloud\_storage\_subscriptions | The list of the Cloud Storage push subscriptions. | `list(map(string))` | `[]` | no |
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
+| grant\_bigquery\_project\_roles | Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA. | `bool` | `true` | no |
 | grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA. | `bool` | `true` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map(any)` | `{}` | no |
 | project\_id | The project ID to manage the Pub/Sub resources. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -32,14 +32,14 @@ resource "google_pubsub_schema" "schema" {
 }
 
 resource "google_project_iam_member" "bigquery_metadata_viewer_binding" {
-  count   = length(var.bigquery_subscriptions) != 0 ? 1 : 0
+  count   = var.grant_bigquery_project_roles && (length(var.bigquery_subscriptions) != 0) ? 1 : 0
   project = var.project_id
   role    = "roles/bigquery.metadataViewer"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"
 }
 
 resource "google_project_iam_member" "bigquery_data_editor_binding" {
-  count   = length(var.bigquery_subscriptions) != 0 ? 1 : 0
+  count   = var.grant_bigquery_project_roles && (length(var.bigquery_subscriptions) != 0) ? 1 : 0
   project = var.project_id
   role    = "roles/bigquery.dataEditor"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,12 @@ variable "topic_kms_key_name" {
   default     = null
 }
 
+variable "grant_bigquery_project_roles" {
+  type        = bool
+  description = "Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA."
+  default     = true
+}
+
 variable "grant_token_creator" {
   type        = bool
   description = "Specify true if you want to add token creator role to the default Pub/Sub SA."


### PR DESCRIPTION
Allow disabling project-wide BQ binding creation, which can be useful when the module is used multiple times.

This avoids destroying bigquery bindings for the whole project when a single module instance is destroyed.