### PR TITLE
feat(TPG>=5.31)!: add cloud storage filename datetime format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ module "pubsub" {
   ]
   cloud_storage_subscriptions = [
     {
-      name            = "cloud-storage"  // required
-      bucket          = "example-bucket" // required
-      filename_prefix = "log_events_"    // optional
-      filename_suffix = ".avro"          // optional
-      max_duration    = "60s"            // optional
-      max_bytes       = "10000000"       // optional
-      output_format   = "avro"           // optional
-      write_metadata  = false            // optional
+      name                     = "cloud-storage"        // required
+      bucket                   = "example-bucket"       // required
+      filename_prefix          = "log_events_"          // optional
+      filename_suffix          = ".avro"                // optional
+      filename_datetime_format = "YYYY-MM-DD/hh_mm_ssZ" // optional
+      max_duration             = "60s"                  // optional
+      max_bytes                = "10000000"             // optional
+      output_format            = "avro"                 // optional
+      write_metadata           = false                  // optional
     }
   ]
 }

--- a/examples/cloud_storage/main.tf
+++ b/examples/cloud_storage/main.tf
@@ -38,6 +38,9 @@ module "pubsub" {
       name   = "example_bucket_subscription"
       bucket = google_storage_bucket.test.name
 
+      filename_prefix = "example_prefix_"
+      filename_suffix = "_example_suffix"
+      filename_datetime_format = "YYYY-MM-DD/hh_mm_ssZ"
       ack_deadline_seconds = 300
     },
   ]

--- a/main.tf
+++ b/main.tf
@@ -434,11 +434,12 @@ resource "google_pubsub_subscription" "cloud_storage_subscriptions" {
   }
 
   cloud_storage_config {
-    bucket          = each.value["bucket"]
-    filename_prefix = lookup(each.value, "filename_prefix", null)
-    filename_suffix = lookup(each.value, "filename_suffix", null)
-    max_duration    = lookup(each.value, "max_duration", null)
-    max_bytes       = lookup(each.value, "max_bytes", null)
+    bucket                   = each.value["bucket"]
+    filename_prefix          = lookup(each.value, "filename_prefix", null)
+    filename_suffix          = lookup(each.value, "filename_suffix", null)
+    filename_datetime_format = lookup(each.value, "filename_datetime_format", null)
+    max_duration             = lookup(each.value, "max_duration", null)
+    max_bytes                = lookup(each.value, "max_bytes", null)
     dynamic "avro_config" {
       for_each = (lookup(each.value, "output_format", "") == "avro") ? [true] : []
       content {

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.78"
+      version = ">= 5.31"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.78"
+      version = ">= 5.31"
     }
     null = {
       source = "hashicorp/null"

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.78, < 6"
+      version = ">= 5.31, < 6"
     }
   }
 


### PR DESCRIPTION
I've tried to add support for this new field following https://github.com/GoogleCloudPlatform/magic-modules/pull/10713. However, I'm having some trouble with having the example in `examples/cloud_storage` pick up the new filename_datetime_format field (it seems to be ignored).

With the updated example which attempts to set filename_prefix, filename_suffix, and filename_datetime_format, I get this with `terraform plan`:

```sh
terraform-google-pubsub/examples/cloud_storage$ terraform init -upgrade

Initializing the backend...
Upgrading modules...
Downloading registry.terraform.io/terraform-google-modules/pubsub/google 6.0.0 for pubsub...
- pubsub in .terraform/modules/pubsub

Initializing provider plugins...
- Finding hashicorp/google versions matching ">= 4.78.0, < 6.0.0"...
- Finding latest version of hashicorp/random...
- Using previously-installed hashicorp/google v5.31.1
- Using previously-installed hashicorp/random v3.6.2

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.



terraform-google-pubsub/examples/cloud_storage$ terraform plan
var.project_id
  The project ID to manage the Pub/Sub resources

  Enter a value: <project>

...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.pubsub.google_pubsub_subscription.cloud_storage_subscriptions["example_bucket_subscription"] will be created
  + resource "google_pubsub_subscription" "cloud_storage_subscriptions" {
      + ack_deadline_seconds       = 300
      + effective_labels           = (known after apply)
      + id                         = (known after apply)
      + message_retention_duration = "604800s"
      + name                       = "example_bucket_subscription"
      + project                    = "<project>"
      + terraform_labels           = (known after apply)
      + topic                      = "cft-tf-pubsub-topic-cloud-storage"

      + cloud_storage_config {
          + bucket          = "test_bucket-ed5de96a"
          + filename_prefix = "example_prefix_"
          + filename_suffix = "_example_suffix"
          + max_duration    = "300s"
          + state           = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

I suspect that the issue might be because the example seems to be stubbornly requiring a version >= 4.78 even though I've changed the versions files to require version >= 5.31.

Would appreciate any insight you might have (maybe I implemented the provider incorrectly, but I'm surprised that it passes the tests in that repo if that's the case).