### PR TITLE
chore: add connection metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA='1' \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh
@@ -76,6 +77,7 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA='1' \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module "pubsub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bigquery\_subscriptions | The list of the Bigquery push subscriptions. | `list(map(string))` | `[]` | no |
+| bigquery\_subscriptions | The list of the Bigquery push subscriptions. | <pre>list(object({<br>              name : string,<br>              table : string,<br>              use_topic_schema : optional(bool, true),<br>              use_table_schema : optional(bool, false),<br>              write_metadata : optional(bool, false),<br>              drop_unknown_fields : optional(bool, false)<br>            }))</pre> | `[]` | no |
 | cloud\_storage\_subscriptions | The list of the Cloud Storage push subscriptions. | `list(map(string))` | `[]` | no |
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ module "pubsub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bigquery\_subscriptions | The list of the Bigquery push subscriptions. | <pre>list(object({<br>              name : string,<br>              table : string,<br>              use_topic_schema : optional(bool, true),<br>              use_table_schema : optional(bool, false),<br>              write_metadata : optional(bool, false),<br>              drop_unknown_fields : optional(bool, false)<br>            }))</pre> | `[]` | no |
-| cloud\_storage\_subscriptions | The list of the Cloud Storage push subscriptions. | `list(map(string))` | `[]` | no |
+| bigquery\_subscriptions | The list of the Bigquery push subscriptions. | <pre>list(object({<br>    name : string,<br>    table : string,<br>    use_topic_schema : optional(bool, true),<br>    use_table_schema : optional(bool, false),<br>    write_metadata : optional(bool, false),<br>    drop_unknown_fields : optional(bool, false)<br>  }))</pre> | `[]` | no |
+| cloud\_storage\_subscriptions | The list of the Cloud Storage push subscriptions. | <pre>list(object({<br>    name : string,<br>    bucket : string,<br>    filename_prefix : optional(string),<br>    filename_suffix : optional(string),<br>    filename_datetime_format : optional(string),<br>    max_duration : optional(string),<br>    max_bytes : optional(string),<br>    max_messages : optional(string),<br>    output_format : optional(string),<br>    write_metadata : optional(bool, false),<br>    use_topic_schema : optional(bool, false),<br>  }))</pre> | `[]` | no |
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
 | grant\_bigquery\_project\_roles | Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA. | `bool` | `true` | no |

--- a/examples/cloud_storage/main.tf
+++ b/examples/cloud_storage/main.tf
@@ -47,8 +47,8 @@ module "pubsub" {
 }
 
 resource "google_storage_bucket" "test" {
-  project  = var.project_id
-  name     = join("-", ["test_bucket", random_id.bucket_suffix.hex])
-  location = "europe-west1"
+  project                     = var.project_id
+  name                        = join("-", ["test_bucket", random_id.bucket_suffix.hex])
+  location                    = "europe-west1"
   uniform_bucket_level_access = true
 }

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -22,7 +22,7 @@ spec:
   info:
     title: terraform-google-pubsub
     source:
-      repo: https://github.com/ktinubu/terraform-google-pubsub.git
+      repo: https://github.com/terraform-google-modules/terraform-google-pubsub
       sourceType: git
   ui:
     input:
@@ -75,3 +75,7 @@ spec:
         topic_message_retention_duration:
           name: topic_message_retention_duration
           title: Topic Message Retention Duration
+    runtime:
+      outputs:
+        service_uri:
+          visibility: VISIBILITY_ROOT

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -73,26 +73,34 @@ spec:
         defaultValue: []
       - name: bigquery_subscriptions
         description: The list of the Bigquery push subscriptions.
-        varType: list(map(string))
+        varType: |-
+          list(object({
+                        name : string,
+                        table : string,
+                        use_topic_schema : optional(bool, true),
+                        use_table_schema : optional(bool, false),
+                        write_metadata : optional(bool, false),
+                        drop_unknown_fields : optional(bool, false)
+                      }))
         defaultValue: []
-          connections:
+        connections:
           - source:
-              source: github.com/terraform-google-modules//terraform-google-bigquery
+              source: github.com/terraform-google-modules/terraform-google-bigquery
               version: ">= 9.0.0"
             spec:
               outputExpr: table_ids[0]
-              inputPath: ["table"]
+              inputPath: table
       - name: cloud_storage_subscriptions
         description: The list of the Cloud Storage push subscriptions.
         varType: list(map(string))
         defaultValue: []
-          connections:
+        connections:
           - source:
-              source: github.com/terraform-google-modules//terraform-google-cloud-storage
+              source: github.com/terraform-google-modules/terraform-google-cloud-storage
               version: ">= 9.0.1"
             spec:
-              inputPath: ["bucket"]
               outputExpr: name
+              inputPath: bucket
       - name: subscription_labels
         description: A map of labels to assign to every Pub/Sub subscription.
         varType: map(string)
@@ -107,13 +115,13 @@ spec:
       - name: topic_kms_key_name
         description: The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic.
         varType: string
-          # connections:
-          # - source:
-          #     source: github.com/terraform-google-modules//terraform-google-kms
-          #     version: ">= 3.2.0"
-          #   spec:
-          #     outputExpr: keys(keys)[0]
-          #     inputPath: topic_kms_key_name
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-kms
+              version: ">= 3.2.0"
+            spec:
+              outputExpr: keys(keys)[0]
+              inputPath: topic_kms_key_name
       - name: grant_bigquery_project_roles
         description: Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA.
         varType: bool

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -75,13 +75,13 @@ spec:
         description: The list of the Bigquery push subscriptions.
         varType: |-
           list(object({
-                        name : string,
-                        table : string,
-                        use_topic_schema : optional(bool, true),
-                        use_table_schema : optional(bool, false),
-                        write_metadata : optional(bool, false),
-                        drop_unknown_fields : optional(bool, false)
-                      }))
+              name : string,
+              table : string,
+              use_topic_schema : optional(bool, true),
+              use_table_schema : optional(bool, false),
+              write_metadata : optional(bool, false),
+              drop_unknown_fields : optional(bool, false)
+            }))
         defaultValue: []
         connections:
           - source:
@@ -92,11 +92,24 @@ spec:
               inputPath: table
       - name: cloud_storage_subscriptions
         description: The list of the Cloud Storage push subscriptions.
-        varType: list(map(string))
+        varType: |-
+          list(object({
+              name : string,
+              bucket : string,
+              filename_prefix : optional(string),
+              filename_suffix : optional(string),
+              filename_datetime_format : optional(string),
+              max_duration : optional(string),
+              max_bytes : optional(string),
+              max_messages : optional(string),
+              output_format : optional(string),
+              write_metadata : optional(bool, false),
+              use_topic_schema : optional(bool, false),
+            }))
         defaultValue: []
         connections:
           - source:
-              source: github.com/terraform-google-modules/terraform-google-cloud-storage
+              source: github.com/terraform-google-modules/terraform-google-cloud-storage//modules/simple_bucket
               version: ">= 9.0.1"
             spec:
               outputExpr: name

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -75,10 +75,24 @@ spec:
         description: The list of the Bigquery push subscriptions.
         varType: list(map(string))
         defaultValue: []
+          connections:
+          - source:
+              source: github.com/terraform-google-modules//terraform-google-bigquery
+              version: ">= 9.0.0"
+            spec:
+              outputExpr: table_ids[0]
+              inputPath: ["table"]
       - name: cloud_storage_subscriptions
         description: The list of the Cloud Storage push subscriptions.
         varType: list(map(string))
         defaultValue: []
+          connections:
+          - source:
+              source: github.com/terraform-google-modules//terraform-google-cloud-storage
+              version: ">= 9.0.1"
+            spec:
+              inputPath: ["bucket"]
+              outputExpr: name
       - name: subscription_labels
         description: A map of labels to assign to every Pub/Sub subscription.
         varType: map(string)
@@ -93,6 +107,13 @@ spec:
       - name: topic_kms_key_name
         description: The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic.
         varType: string
+          # connections:
+          # - source:
+          #     source: github.com/terraform-google-modules//terraform-google-kms
+          #     version: ">= 3.2.0"
+          #   spec:
+          #     outputExpr: keys(keys)[0]
+          #     inputPath: topic_kms_key_name
       - name: grant_bigquery_project_roles
         description: Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA.
         varType: bool

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -113,16 +113,25 @@ spec:
     outputs:
       - name: id
         description: The ID of the Pub/Sub topic
+        type: string
       - name: subscription_names
         description: The name list of Pub/Sub subscriptions
+        type:
+          - tuple
+          - []
       - name: subscription_paths
         description: The path list of Pub/Sub subscriptions
+        type:
+          - tuple
+          - []
       - name: topic
         description: The name of the Pub/Sub topic
+        type: string
       - name: topic_labels
         description: Labels assigned to the Pub/Sub topic
       - name: uri
         description: The URI of the Pub/Sub topic
+        type: string
   requirements:
     roles:
       - level: Project

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,14 @@ variable "pull_subscriptions" {
 }
 
 variable "bigquery_subscriptions" {
-  type        = list(map(string))
+  type = list(object({
+    name : string,
+    table : string,
+    use_topic_schema : optional(bool, true),
+    use_table_schema : optional(bool, false),
+    write_metadata : optional(bool, false),
+    drop_unknown_fields : optional(bool, false)
+  }))
   description = "The list of the Bigquery push subscriptions."
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,19 @@ variable "bigquery_subscriptions" {
 }
 
 variable "cloud_storage_subscriptions" {
-  type        = list(map(string))
+  type = list(object({
+    name : string,
+    bucket : string,
+    filename_prefix : optional(string),
+    filename_suffix : optional(string),
+    filename_datetime_format : optional(string),
+    max_duration : optional(string),
+    max_bytes : optional(string),
+    max_messages : optional(string),
+    output_format : optional(string),
+    write_metadata : optional(bool, false),
+    use_topic_schema : optional(bool, false),
+  }))
   description = "The list of the Cloud Storage push subscriptions."
   default     = []
 }


### PR DESCRIPTION
Add connection metadata:

*  bigquery [module](https://github.com/terraform-google-modules/terraform-google-bigquery) output `table_ids[0]` -> `bigquery_subscription` `table`  (uses first table_id)
*  Cloud storage [module](https://github.com/terraform-google-modules/terraform-google-cloud-storage) output `name` -> `cloud_storage_subscription` `bucket` 
* kms [module](https://github.com/terraform-google-modules/terraform-google-kms) output `keys(keys)[0]` -> `topic_kms_key_name`  (expects `keys` map to contain a single key)