### PR TITLE
chore: generate remaining output type metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -169,10 +169,14 @@ spec:
         type: string
       - name: subscription_names
         description: The name list of Pub/Sub subscriptions
-        type: list(string)
+        type:
+          - tuple
+          - - string
       - name: subscription_paths
         description: The path list of Pub/Sub subscriptions
-        type: list(string)
+        type:
+          - tuple
+          - - string
       - name: topic
         description: The name of the Pub/Sub topic
         type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -169,20 +169,10 @@ spec:
         type: string
       - name: subscription_names
         description: The name list of Pub/Sub subscriptions
-        type:
-          - tuple
-          - - string
-            - string
-            - string
-            - string
+        type: list(string)
       - name: subscription_paths
         description: The path list of Pub/Sub subscriptions
-        type:
-          - tuple
-          - - string
-            - string
-            - string
-            - string
+        type: list(string)
       - name: topic
         description: The name of the Pub/Sub topic
         type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -171,12 +171,18 @@ spec:
         description: The name list of Pub/Sub subscriptions
         type:
           - tuple
-          - []
+          - - string
+            - string
+            - string
+            - string
       - name: subscription_paths
         description: The path list of Pub/Sub subscriptions
         type:
           - tuple
-          - []
+          - - string
+            - string
+            - string
+            - string
       - name: topic
         description: The name of the Pub/Sub topic
         type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -182,6 +182,9 @@ spec:
         type: string
       - name: topic_labels
         description: Labels assigned to the Pub/Sub topic
+        type:
+          - map
+          - string
       - name: uri
         description: The URI of the Pub/Sub topic
         type: string


### PR DESCRIPTION
Generate output type metadata for `subscription_names`,  `subscription_paths` and `topic_labels`

For `subscription_names`,  and `subscription_paths`  autogeneration gave a tuple:

```
type:
          - tuple
          - - string
            - string
            - string
            - string
```
Where the number of strings depended on the number of subscriptions I specified in my  terraform.tfvars:

```
...
pull_subscriptions = [
    {
      name                 = "pull"
      ack_deadline_seconds = 10
    },
    {
      name                 = "pull2"
      ack_deadline_seconds = 10
    },
     {
      name                 = "pull3"
      ack_deadline_seconds = 10
    },
     {
      name                 = "pull4"
      ack_deadline_seconds = 10
    },
  ]
```

I generated the output type metadata using on 1 subscription