### PR TITLE
feat: make granting service agent storage roles optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ module "pubsub" {
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
 | grant\_bigquery\_project\_roles | Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA. | `bool` | `true` | no |
+| grant\_storage\_project\_roles | Specify true if you want to add storage.admin role to the default Pub/Sub SA. | `bool` | `true` | no |
 | grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA. | `bool` | `true` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map(any)` | `{}` | no |
 | project\_id | The project ID to manage the Pub/Sub resources. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_project_iam_member" "bigquery_data_editor_binding" {
 }
 
 resource "google_project_iam_member" "storage_admin_binding" {
-  count   = length(var.cloud_storage_subscriptions) != 0 ? 1 : 0
+  count   = var.grant_storage_project_roles && length(var.cloud_storage_subscriptions) != 0 ? 1 : 0
   project = var.project_id
   role    = "roles/storage.admin"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"

--- a/variables.tf
+++ b/variables.tf
@@ -161,6 +161,12 @@ variable "grant_bigquery_project_roles" {
   default     = true
 }
 
+variable "grant_storage_project_roles" {
+  type        = bool
+  description = "Specify true if you want to add storage.admin role to the default Pub/Sub SA."
+  default     = true
+}
+
 variable "grant_token_creator" {
   type        = bool
   description = "Specify true if you want to add token creator role to the default Pub/Sub SA."


### PR DESCRIPTION
Allow disabling project-wide storage admin role member creation, which can be useful when the module is used multiple times.

This avoids destroying storage admin membership for the whole project when a single module instance is destroyed.

I couldn't figure out how documentation is supposed to be generated and tried to base this off of https://github.com/terraform-google-modules/terraform-google-pubsub/pull/183 .