### PR TITLE
fix: fixed topic regex to make it compatible with golang re2

### DIFF
--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -69,7 +69,7 @@ spec:
         topic:
           name: topic
           title: Topic
-          regexValidation: ^(?!goog)[a-zA-Z][a-zA-Z0-9\-._~%+]{0,254}$
+          regexValidation: ^([a-fh-zA-FH-Z][a-zA-Z0-9\-._~%+]{0,254}|[gG]($|[^oO][a-zA-Z0-9\-._~%+]{0,253}|[oO]($|[^oO][a-zA-Z0-9\-._~%+]{0,252}|[oO]($|[^gG][a-zA-Z0-9\-._~%+]{0,251}))))$
           validation: "ID must start with a letter, and contain only the following characters: letters, numbers, dashes (-), periods (.), underscores (_), tildes (~), percents (%) or plus signs (+). Cannot start with goog. ID must be at most 255 characters long."
         topic_kms_key_name:
           name: topic_kms_key_name


### PR DESCRIPTION
How the regex works ?

1.  `[a-fh-zA-Z][a-zA-Z0-9\-._~%+]{0,254}`: Matches if the string starts with any letter except g, followed by 0 to 254 allowed characters (`a-zA-Z0-9\-._~%+`).
2.  `g(...)`: Matches if the string starts with g, and the rest of the string matches one of the nested alternatives:
    * `$`: The string is exactly `"g"`.
    * `[^o][a-zA-Z0-9\-._~%+]{0,253}`: The second character is not o, followed by 0 to 253 allowed characters.
    * `o(...)`: The second character is o (starts `"go"`), and the rest matches:
        * `$`: The string is exactly `"go"`.
        * `[^o][a-zA-Z0-9\-._~%+]{0,252}`: The third character is **not 'o'**, followed by 0 to 252 allowed characters.
        * `o(...)`: The third character **is 'o'** (starts `"goo"`), and the rest matches:
            * `$`: The string is exactly `"goo"`.
            * `[^g][a-zA-Z0-9\-._~%+]{0,251}`: The fourth character is **not 'g'**, followed by 0 to 251 allowed characters.