### PR TITLE
feat: Add conditional storage iam binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ module "pubsub" {
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
 | grant\_bigquery\_project\_roles | Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA. | `bool` | `true` | no |
+| grant\_cloud\_storage\_project\_roles | Specify true if you want to add storage.admin role to the default Pub/Sub SA. | `bool` | `true` | no |
 | grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA. | `bool` | `true` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map(any)` | `{}` | no |
 | project\_id | The project ID to manage the Pub/Sub resources. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "google_project_iam_member" "bigquery_data_editor_binding" {
 }
 
 resource "google_project_iam_member" "storage_admin_binding" {
-  count   = length(var.cloud_storage_subscriptions) != 0 ? 1 : 0
+  count   = var.grant_cloud_storage_project_roles && length(var.cloud_storage_subscriptions) != 0 ? 1 : 0
   project = var.project_id
   role    = "roles/storage.admin"
   member  = "serviceAccount:${local.pubsub_svc_account_email}"

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -42,6 +42,9 @@ spec:
         grant_bigquery_project_roles:
           name: grant_bigquery_project_roles
           title: Grant Bigquery Project Roles
+        grant_cloud_storage_project_roles:
+          name: grant_cloud_storage_project_roles
+          title: Grant Cloud Storage Project Roles
         grant_token_creator:
           name: grant_token_creator
           title: Grant Token Creator

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -120,6 +120,10 @@ spec:
         description: Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA.
         varType: bool
         defaultValue: true
+      - name: grant_cloud_storage_project_roles
+        description: Specify true if you want to add storage.admin role to the default Pub/Sub SA.
+        varType: bool
+        defaultValue: true
       - name: grant_token_creator
         description: Specify true if you want to add token creator role to the default Pub/Sub SA.
         varType: bool

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "grant_bigquery_project_roles" {
   default     = true
 }
 
+variable "grant_cloud_storage_project_roles" {
+  type        = bool
+  description = "Specify true if you want to add storage.admin role to the default Pub/Sub SA."
+  default     = true
+}
+
 variable "grant_token_creator" {
   type        = bool
   description = "Specify true if you want to add token creator role to the default Pub/Sub SA."


### PR DESCRIPTION
The storage binding is needed for creating GCS subscription.
Although this change can be useful when the module is used multiple times.
This avoids destroying storage bindings for the whole project when a single module instance is destroyed.