### PR TITLE
feat: Add topic publishers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ module "pubsub" {
 | topic\_kms\_key\_name | The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic. | `string` | `null` | no |
 | topic\_labels | A map of labels to assign to the Pub/Sub topic. | `map(string)` | `{}` | no |
 | topic\_message\_retention\_duration | The minimum duration in seconds to retain a message after it is published to the topic. | `string` | `null` | no |
+| topic\_publishers | List of more members that can publish message to topic | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,19 @@ resource "google_pubsub_topic_iam_member" "bigquery_topic_binding" {
   ]
 }
 
+resource "google_pubsub_topic_iam_member" "topic_publishers" {
+  for_each = { for i in var.topic_publishers : i => i }
+
+  project = var.project_id
+  topic   = google_pubsub_topic.topic[0].id
+  role    = "roles/pubsub.publisher"
+  member  = each.value
+  depends_on = [
+    google_pubsub_topic.topic,
+  ]
+}
+
+
 resource "google_pubsub_subscription_iam_member" "pull_subscription_binding" {
   for_each = var.create_subscriptions ? { for i in var.pull_subscriptions : i.name => i if i.dead_letter_topic != null } : {}
 

--- a/main.tf
+++ b/main.tf
@@ -98,8 +98,8 @@ resource "google_pubsub_topic_iam_member" "bigquery_topic_binding" {
   ]
 }
 
-resource "google_pubsub_topic_iam_member" "topic_publishers" {
-  for_each = { for i in var.topic_publishers : i => i }
+resource "google_pubsub_topic_iam_member" "topic_publishers_binding" {
+  for_each = var.create_topic ? { for i in var.topic_publishers : i => i } : {}
 
   project = var.project_id
   topic   = google_pubsub_topic.topic[0].id

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -80,6 +80,9 @@ spec:
         topic_message_retention_duration:
           name: topic_message_retention_duration
           title: Topic Message Retention Duration
+        topic_publishers:
+          name: topic_publishers
+          title: Topic Publishers
     runtime:
       outputs:
         service_uri:

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,9 @@ variable "schema" {
   description = "Schema for the topic."
   default     = null
 }
+
+variable "topic_publishers" {
+  type        = list(string)
+  description = "List of more members that can publish message to topic"
+  default     = []
+}


### PR DESCRIPTION
**Use Case:**

Currently, this module only allows default Google service accounts to publish messages to a Pub/Sub topic. However, there are many scenarios where additional members — such as service accounts used by microservices — need publish permissions for specific topics.

**Proposed Solution:**

Introduce a new variable (similar to bucket_creators in the [Cloud Storage module](https://github.com/terraform-google-modules/terraform-google-cloud-storage?tab=readme-ov-file)) that accepts a list of IAM members. These members will be granted the pubsub.publisher role on the topic, allowing for more flexible and explicit control over who can publish messages.

for example:

```
topic_publishers = [
   "serviceAccount:test@test.com",
   "group:developers@test.com"
]
```
