### PR TITLE
feat: Add option to add topic publishers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ module "pubsub" {
 | topic\_kms\_key\_name | The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic. | `string` | `null` | no |
 | topic\_labels | A map of labels to assign to the Pub/Sub topic. | `map(string)` | `{}` | no |
 | topic\_message\_retention\_duration | The minimum duration in seconds to retain a message after it is published to the topic. | `string` | `null` | no |
+| topic\_publishers | List of more members that can publish message to topic | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,18 @@ resource "google_pubsub_subscription_iam_member" "bigquery_subscription_binding"
   ]
 }
 
+resource "google_pubsub_topic_iam_member" "topic_publishers_binding" {
+  for_each = var.create_topic ? { for i in var.topic_publishers : i => i } : {}
+
+  project = var.project_id
+  topic   = google_pubsub_topic.topic[0].id
+  role    = "roles/pubsub.publisher"
+  member  = each.value
+  depends_on = [
+    google_pubsub_topic.topic,
+  ]
+}
+
 resource "google_pubsub_topic" "topic" {
   count                      = var.create_topic ? 1 : 0
   project                    = var.project_id

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -80,6 +80,9 @@ spec:
         topic_message_retention_duration:
           name: topic_message_retention_duration
           title: Topic Message Retention Duration
+        topic_publishers:
+          name: topic_publishers
+          title: Topic Publishers
     runtime:
       outputs:
         service_uri:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -65,7 +65,26 @@ spec:
         defaultValue: {}
       - name: push_subscriptions
         description: The list of the push subscriptions.
-        varType: "list(object({\r\n    name                       = string,\r\n    ack_deadline_seconds       = optional(number),\r\n    push_endpoint              = optional(string),\r\n    x-goog-version             = optional(string),\r\n    oidc_service_account_email = optional(string),\r\n    audience                   = optional(string),\r\n    expiration_policy          = optional(string),\r\n    dead_letter_topic          = optional(string),\r\n    retain_acked_messages      = optional(bool),\r\n    message_retention_duration = optional(string),\r\n    max_delivery_attempts      = optional(number),\r\n    maximum_backoff            = optional(string),\r\n    minimum_backoff            = optional(string),\r\n    filter                     = optional(string),\r\n    enable_message_ordering    = optional(bool),\r\n    no_wrapper                 = optional(bool),\r\n    write_metadata             = optional(bool),\r\n  }))"
+        varType: |-
+          list(object({
+              name                       = string,
+              ack_deadline_seconds       = optional(number),
+              push_endpoint              = optional(string),
+              x-goog-version             = optional(string),
+              oidc_service_account_email = optional(string),
+              audience                   = optional(string),
+              expiration_policy          = optional(string),
+              dead_letter_topic          = optional(string),
+              retain_acked_messages      = optional(bool),
+              message_retention_duration = optional(string),
+              max_delivery_attempts      = optional(number),
+              maximum_backoff            = optional(string),
+              minimum_backoff            = optional(string),
+              filter                     = optional(string),
+              enable_message_ordering    = optional(bool),
+              no_wrapper                 = optional(bool),
+              write_metadata             = optional(bool),
+            }))
         defaultValue: []
         connections:
           - source:
@@ -75,7 +94,22 @@ spec:
               outputExpr: "{ \"name\": apphub_service_uri.service_id, \"push_endpoint\": service_uri, \"oidc_service_account_email\": service_account_id.email }"
       - name: pull_subscriptions
         description: The list of the pull subscriptions.
-        varType: "list(object({\r\n    name                         = string,\r\n    ack_deadline_seconds         = optional(number),\r\n    expiration_policy            = optional(string),\r\n    dead_letter_topic            = optional(string),\r\n    max_delivery_attempts        = optional(number),\r\n    retain_acked_messages        = optional(bool),\r\n    message_retention_duration   = optional(string),\r\n    maximum_backoff              = optional(string),\r\n    minimum_backoff              = optional(string),\r\n    filter                       = optional(string),\r\n    enable_message_ordering      = optional(bool),\r\n    service_account              = optional(string),\r\n    enable_exactly_once_delivery = optional(bool),\r\n  }))"
+        varType: |-
+          list(object({
+              name                         = string,
+              ack_deadline_seconds         = optional(number),
+              expiration_policy            = optional(string),
+              dead_letter_topic            = optional(string),
+              max_delivery_attempts        = optional(number),
+              retain_acked_messages        = optional(bool),
+              message_retention_duration   = optional(string),
+              maximum_backoff              = optional(string),
+              minimum_backoff              = optional(string),
+              filter                       = optional(string),
+              enable_message_ordering      = optional(bool),
+              service_account              = optional(string),
+              enable_exactly_once_delivery = optional(bool),
+            }))
         defaultValue: []
         connections:
           - source:
@@ -90,7 +124,25 @@ spec:
               outputExpr: "{ \"name\": account_details.id, \"service_account\": account_details.email }"
       - name: bigquery_subscriptions
         description: The list of the Bigquery push subscriptions.
-        varType: "list(object({\r\n    name                       = string,\r\n    table                      = string,\r\n    use_topic_schema           = optional(bool),\r\n    use_table_schema           = optional(bool),\r\n    write_metadata             = optional(bool),\r\n    drop_unknown_fields        = optional(bool),\r\n    ack_deadline_seconds       = optional(number),\r\n    retain_acked_messages      = optional(bool),\r\n    message_retention_duration = optional(string),\r\n    enable_message_ordering    = optional(bool),\r\n    expiration_policy          = optional(string),\r\n    filter                     = optional(string),\r\n    dead_letter_topic          = optional(string),\r\n    max_delivery_attempts      = optional(number),\r\n    maximum_backoff            = optional(string),\r\n    minimum_backoff            = optional(string)\r\n  }))"
+        varType: |-
+          list(object({
+              name                       = string,
+              table                      = string,
+              use_topic_schema           = optional(bool),
+              use_table_schema           = optional(bool),
+              write_metadata             = optional(bool),
+              drop_unknown_fields        = optional(bool),
+              ack_deadline_seconds       = optional(number),
+              retain_acked_messages      = optional(bool),
+              message_retention_duration = optional(string),
+              enable_message_ordering    = optional(bool),
+              expiration_policy          = optional(string),
+              filter                     = optional(string),
+              dead_letter_topic          = optional(string),
+              max_delivery_attempts      = optional(number),
+              maximum_backoff            = optional(string),
+              minimum_backoff            = optional(string)
+            }))
         defaultValue: []
         connections:
           - source:
@@ -100,7 +152,30 @@ spec:
               outputExpr: "{ \"name\": table_ids[0], \"table\": \"${project}:${env_vars.BIGQUERY_DATASET}.${table_ids[0]}\"}"
       - name: cloud_storage_subscriptions
         description: The list of the Cloud Storage push subscriptions.
-        varType: "list(object({\r\n    name                       = string,\r\n    bucket                     = string,\r\n    filename_prefix            = optional(string),\r\n    filename_suffix            = optional(string),\r\n    filename_datetime_format   = optional(string),\r\n    max_duration               = optional(string),\r\n    max_bytes                  = optional(string),\r\n    max_messages               = optional(string),\r\n    output_format              = optional(string),\r\n    write_metadata             = optional(bool),\r\n    use_topic_schema           = optional(bool),\r\n    ack_deadline_seconds       = optional(number),\r\n    retain_acked_messages      = optional(bool),\r\n    message_retention_duration = optional(string),\r\n    enable_message_ordering    = optional(bool),\r\n    expiration_policy          = optional(string),\r\n    filter                     = optional(string),\r\n    dead_letter_topic          = optional(string),\r\n    max_delivery_attempts      = optional(number),\r\n    maximum_backoff            = optional(string),\r\n    minimum_backoff            = optional(string)\r\n  }))"
+        varType: |-
+          list(object({
+              name                       = string,
+              bucket                     = string,
+              filename_prefix            = optional(string),
+              filename_suffix            = optional(string),
+              filename_datetime_format   = optional(string),
+              max_duration               = optional(string),
+              max_bytes                  = optional(string),
+              max_messages               = optional(string),
+              output_format              = optional(string),
+              write_metadata             = optional(bool),
+              use_topic_schema           = optional(bool),
+              ack_deadline_seconds       = optional(number),
+              retain_acked_messages      = optional(bool),
+              message_retention_duration = optional(string),
+              enable_message_ordering    = optional(bool),
+              expiration_policy          = optional(string),
+              filter                     = optional(string),
+              dead_letter_topic          = optional(string),
+              max_delivery_attempts      = optional(number),
+              maximum_backoff            = optional(string),
+              minimum_backoff            = optional(string)
+            }))
         defaultValue: []
         connections:
           - source:
@@ -136,7 +211,17 @@ spec:
         defaultValue: true
       - name: schema
         description: Schema for the topic.
-        varType: "object({\r\n    name       = string\r\n    type       = string\r\n    definition = string\r\n    encoding   = string\r\n  })"
+        varType: |-
+          object({
+              name       = string
+              type       = string
+              definition = string
+              encoding   = string
+            })
+      - name: topic_publishers
+        description: List of more members that can publish message to topic
+        varType: list(string)
+        defaultValue: []
     outputs:
       - name: env_vars
         description: Map of pull subscription IDs, keyed by project_subscription name for environment variables.

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,9 @@ variable "schema" {
   description = "Schema for the topic."
   default     = null
 }
+
+variable "topic_publishers" {
+  type        = list(string)
+  description = "List of more members that can publish message to topic"
+  default     = []
+}


### PR DESCRIPTION
**Use Case:**

Currently, this module only allows default Google service accounts to publish messages to a Pub/Sub topic. However, there are many scenarios where additional members — such as service accounts used by microservices — need publish permissions for specific topics.

**Proposed Solution:**

Introduce a new variable (similar to bucket_creators in the [Cloud Storage module](https://github.com/terraform-google-modules/terraform-google-cloud-storage?tab=readme-ov-file)) that accepts a list of IAM members. These members will be granted the pubsub.publisher role on the topic, allowing for more flexible and explicit control over who can publish messages.

For example:
```
topic_publishers = [
   "serviceAccount:test@test.com",
   "group:developers@test.com"
]
```