### PR TITLE
feat: add per-subscription labels with global defaults merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ module "pubsub" {
 
   topic      = "tf-topic"
   project_id = "my-pubsub-project"
+  
+  # Global labels applied to all subscriptions
+  subscription_labels = {
+    environment = "production"
+    team        = "platform"
+  }
+  
   push_subscriptions = [
     {
       name                       = "push"                                               // required
@@ -35,6 +42,10 @@ module "pubsub" {
       minimum_backoff            = "300s"                                               // optional
       filter                     = "attributes.domain = \"com\""                        // optional
       enable_message_ordering    = true                                                 // optional
+      labels = {                                                                        // optional
+        service = "billing"
+        region  = "us-central1"
+      }
     }
   ]
   pull_subscriptions = [
@@ -49,6 +60,9 @@ module "pubsub" {
       enable_message_ordering      = true                                                 // optional
       service_account              = "service2@project2.iam.gserviceaccount.com"          // optional
       enable_exactly_once_delivery = true                                                 // optional
+      labels = {                                                                          // optional
+        service = "analytics"
+      }
     }
   ]
   bigquery_subscriptions = [
@@ -59,6 +73,9 @@ module "pubsub" {
       use_table_schema    = false                   // optional
       write_metadata      = false                   // optional
       drop_unknown_fields = false                   // optional
+      labels = {                                    // optional
+        destination = "warehouse"
+      }
     }
   ]
   cloud_storage_subscriptions = [
@@ -74,6 +91,9 @@ module "pubsub" {
       output_format            = "avro"                 // optional
       write_metadata           = false                  // optional
       use_topic_schema         = false                  // optional
+      labels = {                                        // optional
+        storage_type = "archive"
+      }
     }
   ]
 }
@@ -84,8 +104,8 @@ module "pubsub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bigquery\_subscriptions | The list of the Bigquery push subscriptions. | <pre>list(object({<br>    name                       = string,<br>    table                      = string,<br>    use_topic_schema           = optional(bool),<br>    use_table_schema           = optional(bool),<br>    write_metadata             = optional(bool),<br>    drop_unknown_fields        = optional(bool),<br>    ack_deadline_seconds       = optional(number),<br>    retain_acked_messages      = optional(bool),<br>    message_retention_duration = optional(string),<br>    enable_message_ordering    = optional(bool),<br>    expiration_policy          = optional(string),<br>    filter                     = optional(string),<br>    dead_letter_topic          = optional(string),<br>    max_delivery_attempts      = optional(number),<br>    maximum_backoff            = optional(string),<br>    minimum_backoff            = optional(string)<br>  }))</pre> | `[]` | no |
-| cloud\_storage\_subscriptions | The list of the Cloud Storage push subscriptions. | <pre>list(object({<br>    name                       = string,<br>    bucket                     = string,<br>    filename_prefix            = optional(string),<br>    filename_suffix            = optional(string),<br>    filename_datetime_format   = optional(string),<br>    max_duration               = optional(string),<br>    max_bytes                  = optional(string),<br>    max_messages               = optional(string),<br>    output_format              = optional(string),<br>    write_metadata             = optional(bool),<br>    use_topic_schema           = optional(bool),<br>    ack_deadline_seconds       = optional(number),<br>    retain_acked_messages      = optional(bool),<br>    message_retention_duration = optional(string),<br>    enable_message_ordering    = optional(bool),<br>    expiration_policy          = optional(string),<br>    filter                     = optional(string),<br>    dead_letter_topic          = optional(string),<br>    max_delivery_attempts      = optional(number),<br>    maximum_backoff            = optional(string),<br>    minimum_backoff            = optional(string)<br>  }))</pre> | `[]` | no |
+| bigquery\_subscriptions | The list of the Bigquery push subscriptions. | <pre>list(object({<br>    name                       = string,<br>    table                      = string,<br>    use_topic_schema           = optional(bool),<br>    use_table_schema           = optional(bool),<br>    write_metadata             = optional(bool),<br>    drop_unknown_fields        = optional(bool),<br>    ack_deadline_seconds       = optional(number),<br>    retain_acked_messages      = optional(bool),<br>    message_retention_duration = optional(string),<br>    enable_message_ordering    = optional(bool),<br>    expiration_policy          = optional(string),<br>    filter                     = optional(string),<br>    dead_letter_topic          = optional(string),<br>    max_delivery_attempts      = optional(number),<br>    maximum_backoff            = optional(string),<br>    minimum_backoff            = optional(string),<br>    labels                     = optional(map(string)),<br>  }))</pre> | `[]` | no |
+| cloud\_storage\_subscriptions | The list of the Cloud Storage push subscriptions. | <pre>list(object({<br>    name                       = string,<br>    bucket                     = string,<br>    filename_prefix            = optional(string),<br>    filename_suffix            = optional(string),<br>    filename_datetime_format   = optional(string),<br>    max_duration               = optional(string),<br>    max_bytes                  = optional(string),<br>    max_messages               = optional(string),<br>    output_format              = optional(string),<br>    write_metadata             = optional(bool),<br>    use_topic_schema           = optional(bool),<br>    ack_deadline_seconds       = optional(number),<br>    retain_acked_messages      = optional(bool),<br>    message_retention_duration = optional(string),<br>    enable_message_ordering    = optional(bool),<br>    expiration_policy          = optional(string),<br>    filter                     = optional(string),<br>    dead_letter_topic          = optional(string),<br>    max_delivery_attempts      = optional(number),<br>    maximum_backoff            = optional(string),<br>    minimum_backoff            = optional(string),<br>    labels                     = optional(map(string)),<br>  }))</pre> | `[]` | no |
 | create\_subscriptions | Specify true if you want to create subscriptions. | `bool` | `true` | no |
 | create\_topic | Specify true if you want to create a topic. | `bool` | `true` | no |
 | grant\_bigquery\_project\_roles | Specify true if you want to add bigquery.metadataViewer and bigquery.dataEditor roles to the default Pub/Sub SA. | `bool` | `true` | no |
@@ -93,8 +113,8 @@ module "pubsub" {
 | grant\_token\_creator | Specify true if you want to add token creator role to the default Pub/Sub SA. | `bool` | `true` | no |
 | message\_storage\_policy | A map of storage policies. Default - inherit from organization's Resource Location Restriction policy. | `map(any)` | `{}` | no |
 | project\_id | The project ID to manage the Pub/Sub resources. | `string` | n/a | yes |
-| pull\_subscriptions | The list of the pull subscriptions. | <pre>list(object({<br>    name                         = string,<br>    ack_deadline_seconds         = optional(number),<br>    expiration_policy            = optional(string),<br>    dead_letter_topic            = optional(string),<br>    max_delivery_attempts        = optional(number),<br>    retain_acked_messages        = optional(bool),<br>    message_retention_duration   = optional(string),<br>    maximum_backoff              = optional(string),<br>    minimum_backoff              = optional(string),<br>    filter                       = optional(string),<br>    enable_message_ordering      = optional(bool),<br>    service_account              = optional(string),<br>    enable_exactly_once_delivery = optional(bool),<br>  }))</pre> | `[]` | no |
-| push\_subscriptions | The list of the push subscriptions. | <pre>list(object({<br>    name                       = string,<br>    ack_deadline_seconds       = optional(number),<br>    push_endpoint              = optional(string),<br>    x-goog-version             = optional(string),<br>    oidc_service_account_email = optional(string),<br>    audience                   = optional(string),<br>    expiration_policy          = optional(string),<br>    dead_letter_topic          = optional(string),<br>    retain_acked_messages      = optional(bool),<br>    message_retention_duration = optional(string),<br>    max_delivery_attempts      = optional(number),<br>    maximum_backoff            = optional(string),<br>    minimum_backoff            = optional(string),<br>    filter                     = optional(string),<br>    enable_message_ordering    = optional(bool),<br>    no_wrapper                 = optional(bool),<br>    write_metadata             = optional(bool),<br>  }))</pre> | `[]` | no |
+| pull\_subscriptions | The list of the pull subscriptions. | <pre>list(object({<br>    name                         = string,<br>    ack_deadline_seconds         = optional(number),<br>    expiration_policy            = optional(string),<br>    dead_letter_topic            = optional(string),<br>    max_delivery_attempts        = optional(number),<br>    retain_acked_messages        = optional(bool),<br>    message_retention_duration   = optional(string),<br>    maximum_backoff              = optional(string),<br>    minimum_backoff              = optional(string),<br>    filter                       = optional(string),<br>    enable_message_ordering      = optional(bool),<br>    service_account              = optional(string),<br>    enable_exactly_once_delivery = optional(bool),<br>    labels                       = optional(map(string)),<br>  }))</pre> | `[]` | no |
+| push\_subscriptions | The list of the push subscriptions. | <pre>list(object({<br>    name                       = string,<br>    ack_deadline_seconds       = optional(number),<br>    push_endpoint              = optional(string),<br>    x-goog-version             = optional(string),<br>    oidc_service_account_email = optional(string),<br>    audience                   = optional(string),<br>    expiration_policy          = optional(string),<br>    dead_letter_topic          = optional(string),<br>    retain_acked_messages      = optional(bool),<br>    message_retention_duration = optional(string),<br>    max_delivery_attempts      = optional(number),<br>    maximum_backoff            = optional(string),<br>    minimum_backoff            = optional(string),<br>    filter                     = optional(string),<br>    enable_message_ordering    = optional(bool),<br>    no_wrapper                 = optional(bool),<br>    write_metadata             = optional(bool),<br>    labels                     = optional(map(string)),<br>  }))</pre> | `[]` | no |
 | schema | Schema for the topic. | <pre>object({<br>    name       = string<br>    type       = string<br>    definition = string<br>    encoding   = string<br>  })</pre> | `null` | no |
 | subscription\_labels | A map of labels to assign to every Pub/Sub subscription. | `map(string)` | `{}` | no |
 | topic | The Pub/Sub topic name. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -170,10 +170,13 @@ resource "google_pubsub_topic" "topic" {
 resource "google_pubsub_subscription" "push_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.push_subscriptions : i.name => i } : {}
 
-  name                       = each.value.name
-  topic                      = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
-  project                    = var.project_id
-  labels                     = var.subscription_labels
+  name    = each.value.name
+  topic   = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
+  project = var.project_id
+  labels = merge(
+    var.subscription_labels,
+    lookup(each.value, "labels", {})
+  )
   ack_deadline_seconds       = each.value.ack_deadline_seconds != null ? each.value.ack_deadline_seconds : local.default_ack_deadline_seconds
   message_retention_duration = each.value.message_retention_duration
   retain_acked_messages      = each.value.retain_acked_messages
@@ -234,10 +237,13 @@ resource "google_pubsub_subscription" "push_subscriptions" {
 resource "google_pubsub_subscription" "pull_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.pull_subscriptions : i.name => i } : {}
 
-  name                         = each.value.name
-  topic                        = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
-  project                      = var.project_id
-  labels                       = var.subscription_labels
+  name    = each.value.name
+  topic   = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
+  project = var.project_id
+  labels = merge(
+    var.subscription_labels,
+    lookup(each.value, "labels", {})
+  )
   enable_exactly_once_delivery = each.value.enable_exactly_once_delivery
   ack_deadline_seconds         = each.value.ack_deadline_seconds != null ? each.value.ack_deadline_seconds : local.default_ack_deadline_seconds
   message_retention_duration   = each.value.message_retention_duration
@@ -276,10 +282,13 @@ resource "google_pubsub_subscription" "pull_subscriptions" {
 resource "google_pubsub_subscription" "bigquery_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.bigquery_subscriptions : i.name => i } : {}
 
-  name                       = each.value.name
-  topic                      = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
-  project                    = var.project_id
-  labels                     = var.subscription_labels
+  name    = each.value.name
+  topic   = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
+  project = var.project_id
+  labels = merge(
+    var.subscription_labels,
+    lookup(each.value, "labels", {})
+  )
   ack_deadline_seconds       = each.value.ack_deadline_seconds != null ? each.value.ack_deadline_seconds : local.default_ack_deadline_seconds
   message_retention_duration = each.value.message_retention_duration
   retain_acked_messages      = each.value.retain_acked_messages
@@ -327,10 +336,13 @@ resource "google_pubsub_subscription" "bigquery_subscriptions" {
 resource "google_pubsub_subscription" "cloud_storage_subscriptions" {
   for_each = var.create_subscriptions ? { for i in var.cloud_storage_subscriptions : i.name => i } : {}
 
-  name                       = each.value.name
-  topic                      = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
-  project                    = var.project_id
-  labels                     = var.subscription_labels
+  name    = each.value.name
+  topic   = var.create_topic ? google_pubsub_topic.topic[0].name : var.topic
+  project = var.project_id
+  labels = merge(
+    var.subscription_labels,
+    lookup(each.value, "labels", {})
+  )
   ack_deadline_seconds       = each.value.ack_deadline_seconds != null ? each.value.ack_deadline_seconds : local.default_ack_deadline_seconds
   message_retention_duration = each.value.message_retention_duration
   retain_acked_messages      = each.value.retain_acked_messages

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,7 @@ variable "push_subscriptions" {
     enable_message_ordering    = optional(bool),
     no_wrapper                 = optional(bool),
     write_metadata             = optional(bool),
+    labels                     = optional(map(string)),
   }))
   description = "The list of the push subscriptions."
   default     = []
@@ -80,6 +81,7 @@ variable "pull_subscriptions" {
     enable_message_ordering      = optional(bool),
     service_account              = optional(string),
     enable_exactly_once_delivery = optional(bool),
+    labels                       = optional(map(string)),
   }))
   description = "The list of the pull subscriptions."
   default     = []
@@ -102,7 +104,8 @@ variable "bigquery_subscriptions" {
     dead_letter_topic          = optional(string),
     max_delivery_attempts      = optional(number),
     maximum_backoff            = optional(string),
-    minimum_backoff            = optional(string)
+    minimum_backoff            = optional(string),
+    labels                     = optional(map(string)),
   }))
   description = "The list of the Bigquery push subscriptions."
   default     = []
@@ -130,7 +133,8 @@ variable "cloud_storage_subscriptions" {
     dead_letter_topic          = optional(string),
     max_delivery_attempts      = optional(number),
     maximum_backoff            = optional(string),
-    minimum_backoff            = optional(string)
+    minimum_backoff            = optional(string),
+    labels                     = optional(map(string)),
   }))
   description = "The list of the Cloud Storage push subscriptions."
   default     = []


### PR DESCRIPTION
## Description

Adds support for per-subscription labels that merge with global `subscription_labels`, allowing fine-grained control while maintaining backward compatibility.

## Problem

PR #271 addressed this need but was incomplete (only `push_subscriptions`) and lacked documentation, leading to closure.

## Solution

- Added optional `labels` field to **all** subscription types (push, pull, bigquery, cloud_storage)
- Labels automatically merge: global defaults + subscription-specific overrides
- 100% backward compatible

## Example

```hcl
module "pubsub" {
  source = "terraform-google-modules/pubsub/google"
  
  # Global labels for ALL subscriptions
  subscription_labels = {
    environment = "production"
    team        = "platform"
  }
  
  push_subscriptions = [
    {
      name          = "billing-service"
      push_endpoint = "https://example.com"
      labels = {
        service = "billing"
        team    = "billing-team"  # Overrides global
      }
      # Result: environment=production, team=billing-team, service=billing
    }
  ]
}
```
